### PR TITLE
Allow customisation of encrypted property placeholder definition rather than being always hardcoded to ENC().

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,9 +251,9 @@ Note that the bean name is required, as `jasypt-spring-boot` detects custom Prop
 
 But one can also override this by defining the property:
 
-``` jasypt.encryptor.propertyFinder ```
+``` jasypt.propertyFinder.bean ```
 
-So for instance, if you define `jasypt.encryptor.propertyFinder=finderBean` then you would define your custom finder with that name:
+So for instance, if you define `jasypt.propertyFinder.bean=finderBean` then you would define your custom finder with that name:
 
 ```java
     @Bean(name = "finderBean")

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/EnableEncryptablePropertySourcesPostProcessor.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/EnableEncryptablePropertySourcesPostProcessor.java
@@ -1,5 +1,6 @@
 package com.ulisesbocchio.jasyptspringboot;
 
+import com.ulisesbocchio.jasyptspringboot.properties.PropertyFinder;
 import org.jasypt.encryption.StringEncryptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,7 +20,8 @@ import java.util.stream.StreamSupport;
 
 import static com.ulisesbocchio.jasyptspringboot.EncryptablePropertySourceConverter.instantiatePropertySource;
 import static com.ulisesbocchio.jasyptspringboot.EncryptablePropertySourceConverter.proxyPropertySource;
-import static com.ulisesbocchio.jasyptspringboot.configuration.StringEncryptorConfiguration.ENCRYPTOR_BEAN_PLACEHOLDER;
+import static com.ulisesbocchio.jasyptspringboot.configuration.PlaceHolderInitialisation.ENCRYPTOR_BEAN_PLACEHOLDER;
+import static com.ulisesbocchio.jasyptspringboot.configuration.PlaceHolderInitialisation.PROPERTY_FINDER_BEAN_PLACEHOLDER;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -50,8 +52,9 @@ public class EnableEncryptablePropertySourcesPostProcessor implements BeanFactor
 
     private <T> PropertySource<T> makeEncryptable(PropertySource<T> propertySource, ConfigurableListableBeanFactory registry) {
         StringEncryptor encryptor = registry.getBean(environment.resolveRequiredPlaceholders(ENCRYPTOR_BEAN_PLACEHOLDER), StringEncryptor.class);
+        PropertyFinder propertyFinder = registry.getBean(environment.resolveRequiredPlaceholders(PROPERTY_FINDER_BEAN_PLACEHOLDER), PropertyFinder.class);
         PropertySource<T> encryptablePropertySource = interceptionMode == InterceptionMode.PROXY
-                ? proxyPropertySource(propertySource, encryptor) : instantiatePropertySource(propertySource, encryptor);
+                ? proxyPropertySource(propertySource, encryptor, propertyFinder) : instantiatePropertySource(propertySource, encryptor, propertyFinder);
         LOG.info("Converting PropertySource {} [{}] to {}", propertySource.getName(), propertySource.getClass().getName(),
                 AopUtils.isAopProxy(encryptablePropertySource) ? "AOP Proxy" : encryptablePropertySource.getClass().getSimpleName());
         return encryptablePropertySource;

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/EncryptablePropertySource.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/EncryptablePropertySource.java
@@ -12,11 +12,11 @@ import org.springframework.core.env.PropertySource;
 public interface EncryptablePropertySource<T> {
     public default Object getProperty(StringEncryptor encryptor, PropertySource<T> source, String name) {
         Object value = source.getProperty(name);
-        if(value instanceof String) {
+        if (value instanceof String) {
             String stringValue = String.valueOf(value);
-            if(PropertyValueEncryptionUtils.isEncryptedValue(stringValue)) {
+            if (isEncryptedValue(stringValue)) {
                 try {
-                    value = PropertyValueEncryptionUtils.decrypt(stringValue, encryptor);
+                    value = this.decrypt(stringValue, encryptor);
                 } catch (EncryptionOperationNotPossibleException e) {
                     throw new DecryptionException("Decryption of Properties failed,  make sure encryption/decryption " +
                             "passwords match", e);
@@ -25,4 +25,10 @@ public interface EncryptablePropertySource<T> {
         }
         return value;
     }
+
+    default boolean isEncryptedValue(String stringValue) {
+        return PropertyValueEncryptionUtils.isEncryptedValue(stringValue);
+    }
+
+    String decrypt(final String encodedValue, final StringEncryptor encryptor);
 }

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/EncryptablePropertySourceConverter.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/EncryptablePropertySourceConverter.java
@@ -1,6 +1,7 @@
 package com.ulisesbocchio.jasyptspringboot;
 
 import com.ulisesbocchio.jasyptspringboot.aop.EncryptablePropertySourceMethodInterceptor;
+import com.ulisesbocchio.jasyptspringboot.properties.PropertyFinder;
 import com.ulisesbocchio.jasyptspringboot.wrapper.EncryptableEnumerablePropertySourceWrapper;
 import com.ulisesbocchio.jasyptspringboot.wrapper.EncryptableMapPropertySourceWrapper;
 import com.ulisesbocchio.jasyptspringboot.wrapper.EncryptablePropertySourceWrapper;
@@ -16,33 +17,33 @@ import org.springframework.core.env.PropertySource;
  */
 public class EncryptablePropertySourceConverter {
     @SuppressWarnings("unchecked")
-    public static <T> PropertySource<T> proxyPropertySource(PropertySource<T> propertySource, StringEncryptor encryptor) {
+    public static <T> PropertySource<T> proxyPropertySource(PropertySource<T> propertySource, StringEncryptor encryptor, PropertyFinder propertyFinder) {
         //Silly Chris Beams for making CommandLinePropertySource getProperty and containsProperty methods final. Those methods
         //can't be proxied with CGLib because of it. So fallback to wrapper for Command Line Arguments only.
         if (CommandLinePropertySource.class.isAssignableFrom(propertySource.getClass())) {
-            return instantiatePropertySource(propertySource, encryptor);
+            return instantiatePropertySource(propertySource, encryptor, propertyFinder);
         }
         ProxyFactory proxyFactory = new ProxyFactory();
         proxyFactory.setTargetClass(propertySource.getClass());
         proxyFactory.setProxyTargetClass(true);
         proxyFactory.addInterface(EncryptablePropertySource.class);
         proxyFactory.setTarget(propertySource);
-        proxyFactory.addAdvice(new EncryptablePropertySourceMethodInterceptor<>(encryptor));
+        proxyFactory.addAdvice(new EncryptablePropertySourceMethodInterceptor<>(encryptor, propertyFinder));
         return (PropertySource<T>) proxyFactory.getProxy();
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> PropertySource<T> instantiatePropertySource(PropertySource<T> propertySource, StringEncryptor encryptor) {
+    public static <T> PropertySource<T> instantiatePropertySource(PropertySource<T> propertySource, StringEncryptor encryptor, PropertyFinder propertyFinder) {
         PropertySource<T> encryptablePropertySource;
         if (propertySource instanceof MapPropertySource) {
-            encryptablePropertySource = (PropertySource<T>) new EncryptableMapPropertySourceWrapper((MapPropertySource) propertySource, encryptor);
+            encryptablePropertySource = (PropertySource<T>) new EncryptableMapPropertySourceWrapper((MapPropertySource) propertySource, encryptor, propertyFinder);
         } else if (propertySource.getClass().getName().equals("org.springframework.boot.context.config.ConfigFileApplicationListener$ConfigurationPropertySources")) {
             //Some Spring Boot code actually casts property sources to this specific type so must be proxied.
-            encryptablePropertySource = proxyPropertySource(propertySource, encryptor);
+            encryptablePropertySource = proxyPropertySource(propertySource, encryptor, propertyFinder);
         } else if (propertySource instanceof EnumerablePropertySource) {
-            encryptablePropertySource = new EncryptableEnumerablePropertySourceWrapper<>((EnumerablePropertySource) propertySource, encryptor);
+            encryptablePropertySource = new EncryptableEnumerablePropertySourceWrapper<>((EnumerablePropertySource) propertySource, encryptor, propertyFinder);
         } else {
-            encryptablePropertySource = new EncryptablePropertySourceWrapper<>(propertySource, encryptor);
+            encryptablePropertySource = new EncryptablePropertySourceWrapper<>(propertySource, encryptor, propertyFinder);
         }
         return encryptablePropertySource;
     }

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/aop/EncryptablePropertySourceMethodInterceptor.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/aop/EncryptablePropertySourceMethodInterceptor.java
@@ -1,7 +1,7 @@
 package com.ulisesbocchio.jasyptspringboot.aop;
 
 import com.ulisesbocchio.jasyptspringboot.EncryptablePropertySource;
-
+import com.ulisesbocchio.jasyptspringboot.properties.PropertyFinder;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.jasypt.encryption.StringEncryptor;
@@ -13,18 +13,30 @@ import org.springframework.core.env.PropertySource;
 public class EncryptablePropertySourceMethodInterceptor<T> implements MethodInterceptor, EncryptablePropertySource<T> {
 
     private final StringEncryptor encryptor;
+    private final PropertyFinder propertyFinder;
 
-    public EncryptablePropertySourceMethodInterceptor(StringEncryptor encryptor) {
+    public EncryptablePropertySourceMethodInterceptor(StringEncryptor encryptor, PropertyFinder propertyFinder) {
         this.encryptor = encryptor;
+        this.propertyFinder = propertyFinder;
     }
 
     @Override
     public Object invoke(MethodInvocation invocation) throws Throwable {
         Object returnValue = invocation.proceed();
-        if(isGetPropertyCall(invocation)) {
+        if (isGetPropertyCall(invocation)) {
             return getProperty(encryptor, getPropertySource(invocation), getNameArgument(invocation));
         }
         return returnValue;
+    }
+
+    @Override
+    public boolean isEncryptedValue(String stringValue) {
+        return propertyFinder.isEncryptedValue(stringValue);
+    }
+
+    @Override
+    public String decrypt(String encodedValue, StringEncryptor encryptor) {
+        return propertyFinder.decrypt(encodedValue, encryptor);
     }
 
     @SuppressWarnings("unchecked")

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/EnableEncryptablePropertySourcesConfiguration.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/EnableEncryptablePropertySourcesConfiguration.java
@@ -2,13 +2,11 @@ package com.ulisesbocchio.jasyptspringboot.configuration;
 
 import com.ulisesbocchio.jasyptspringboot.EnableEncryptablePropertySourcesPostProcessor;
 import com.ulisesbocchio.jasyptspringboot.InterceptionMode;
-
 import org.jasypt.encryption.StringEncryptor;
 import org.jasypt.encryption.pbe.config.StringPBEConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
-import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -55,7 +53,7 @@ import org.springframework.core.env.PropertySource;
  * @author Ulises Bocchio
  */
 @Configuration
-@Import(StringEncryptorConfiguration.class)
+@Import({StringEncryptorConfiguration.class, PropertyFinderConfiguration.class, PlaceHolderInitialisation.class})
 public class EnableEncryptablePropertySourcesConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(EnableEncryptablePropertySourcesConfiguration.class);

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/PlaceHolderInitialisation.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/PlaceHolderInitialisation.java
@@ -1,0 +1,71 @@
+package com.ulisesbocchio.jasyptspringboot.configuration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.Environment;
+
+import java.util.stream.Stream;
+
+/**
+ * @author Ulises Bocchio
+ */
+@Configuration
+public class PlaceHolderInitialisation {
+
+    public static final String ENCRYPTOR_BEAN_PLACEHOLDER = "${jasypt.encryptor.bean:jasyptStringEncryptor}";
+    public static final String PROPERTY_FINDER_BEAN_PLACEHOLDER = "${jasypt.propertyFinder.bean:jasyptPropertyFinder}";
+
+    private static final Logger LOG = LoggerFactory.getLogger(PlaceHolderInitialisation.class);
+
+    @Bean
+    public static BeanNamePlaceholderRegistryPostProcessor beanNamePlaceholderRegistryPostProcessor(Environment environment) {
+        return new BeanNamePlaceholderRegistryPostProcessor(environment);
+    }
+
+    /**
+     * Bean Definition Registry Post Processor that looks for placeholders in bean names and resolves them, re-defining those beans
+     * with the new names.
+     */
+    static class BeanNamePlaceholderRegistryPostProcessor implements BeanDefinitionRegistryPostProcessor, Ordered {
+
+        private Environment environment;
+
+        private BeanNamePlaceholderRegistryPostProcessor(Environment environment) {
+            this.environment = environment;
+        }
+
+        @Override
+        public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+            DefaultListableBeanFactory bf = (DefaultListableBeanFactory) registry;
+            Stream.of(bf.getBeanDefinitionNames())
+                // Look for beans with one of the placeholders we support
+                .filter(name -> name.equals(ENCRYPTOR_BEAN_PLACEHOLDER) || name.equals(PROPERTY_FINDER_BEAN_PLACEHOLDER))
+                .forEach(placeholder -> {
+                    String actualName = environment.resolveRequiredPlaceholders(placeholder);
+                    BeanDefinition bd = bf.getBeanDefinition(placeholder);
+                    bf.removeBeanDefinition(placeholder);
+                    bf.registerBeanDefinition(actualName, bd);
+                    LOG.debug("Registering new name '{}' for Bean definition with placeholder name: {}", actualName, placeholder);
+                });
+        }
+
+        @Override
+        public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+
+        }
+
+        @Override
+        public int getOrder() {
+            return Ordered.LOWEST_PRECEDENCE - 1;
+        }
+    }
+}

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/PropertyFinderConfiguration.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/PropertyFinderConfiguration.java
@@ -22,13 +22,12 @@ public class PropertyFinderConfiguration {
     @Bean(name = PROPERTY_FINDER_BEAN_PLACEHOLDER)
     public PropertyFinder propertyFinder(Environment environment) {
         String propertyFinderBeanName = environment.resolveRequiredPlaceholders(PROPERTY_FINDER_BEAN_PLACEHOLDER);
-        LOG.info("Property Finder custom Bean not found with name '{}'. Initializing default JasyptPropertyFinder",
-                propertyFinderBeanName);
+        LOG.info("Property Finder custom Bean not found with name '{}'. Initializing default JasyptPropertyFinder", propertyFinderBeanName);
         return new JasyptPropertyFinder();
     }
 
     /**
-     * Condition that checks whether the StringEncryptor specified by placeholder: {@link PlaceHolderInitialisation#PROPERTY_FINDER_BEAN_PLACEHOLDER} exists.
+     * Condition that checks whether the PropertyFinder specified by placeholder: {@link PlaceHolderInitialisation#PROPERTY_FINDER_BEAN_PLACEHOLDER} exists.
      * ConditionalOnMissingBean does not support placeholder resolution.
      */
     private static class OnMissingPropertyFinderBean implements ConfigurationCondition {

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/PropertyFinderConfiguration.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/PropertyFinderConfiguration.java
@@ -1,0 +1,47 @@
+package com.ulisesbocchio.jasyptspringboot.configuration;
+
+import com.ulisesbocchio.jasyptspringboot.properties.JasyptPropertyFinder;
+import com.ulisesbocchio.jasyptspringboot.properties.PropertyFinder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.*;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import static com.ulisesbocchio.jasyptspringboot.configuration.PlaceHolderInitialisation.PROPERTY_FINDER_BEAN_PLACEHOLDER;
+
+/**
+ * @author Ulises Bocchio
+ */
+@Configuration
+public class PropertyFinderConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PropertyFinderConfiguration.class);
+
+    @Conditional(OnMissingPropertyFinderBean.class)
+    @Bean(name = PROPERTY_FINDER_BEAN_PLACEHOLDER)
+    public PropertyFinder propertyFinder(Environment environment) {
+        String propertyFinderBeanName = environment.resolveRequiredPlaceholders(PROPERTY_FINDER_BEAN_PLACEHOLDER);
+        LOG.info("Property Finder custom Bean not found with name '{}'. Initializing default JasyptPropertyFinder",
+                propertyFinderBeanName);
+        return new JasyptPropertyFinder();
+    }
+
+    /**
+     * Condition that checks whether the StringEncryptor specified by placeholder: {@link PlaceHolderInitialisation#PROPERTY_FINDER_BEAN_PLACEHOLDER} exists.
+     * ConditionalOnMissingBean does not support placeholder resolution.
+     */
+    private static class OnMissingPropertyFinderBean implements ConfigurationCondition {
+
+        @Override
+        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            return !context.getBeanFactory().containsBean(context.getEnvironment().resolveRequiredPlaceholders(PROPERTY_FINDER_BEAN_PLACEHOLDER));
+        }
+
+        @Override
+        public ConfigurationPhase getConfigurationPhase() {
+            return ConfigurationPhase.REGISTER_BEAN;
+        }
+    }
+
+}

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/properties/EncryptablePropertySourcesConfigurationProperties.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/properties/EncryptablePropertySourcesConfigurationProperties.java
@@ -24,6 +24,8 @@ public class EncryptablePropertySourcesConfigurationProperties {
    */
   private String bean = "jasyptStringEncryptor";
 
+  private String propertyFinder = "jasyptPropertyFinder";
+
   public Boolean getProxyPropertySources() {
     return proxyPropertySources;
   }
@@ -38,5 +40,17 @@ public class EncryptablePropertySourcesConfigurationProperties {
 
   public void setBean(String bean) {
     this.bean = bean;
+  }
+
+  /**
+   * Specify the name of bean to override jasypt-spring-boot's default properties based {@link JasyptPropertyFinder}.
+   * Default Value is {@code jasyptPropertyFinder}.
+   */
+  public String getPropertyFinder() {
+    return propertyFinder;
+  }
+
+  public void setPropertyFinder(String propertyFinder) {
+    this.propertyFinder = propertyFinder;
   }
 }

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/properties/JasyptPropertyFinder.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/properties/JasyptPropertyFinder.java
@@ -1,0 +1,16 @@
+package com.ulisesbocchio.jasyptspringboot.properties;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.properties.PropertyValueEncryptionUtils;
+
+public class JasyptPropertyFinder implements PropertyFinder {
+    @Override
+    public boolean isEncryptedValue(String stringValue) {
+        return PropertyValueEncryptionUtils.isEncryptedValue(stringValue);
+    }
+
+    @Override
+    public String decrypt(final String encodedValue, final StringEncryptor encryptor) {
+        return PropertyValueEncryptionUtils.decrypt(encodedValue, encryptor);
+    }
+}

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/properties/PropertyFinder.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/properties/PropertyFinder.java
@@ -1,0 +1,21 @@
+package com.ulisesbocchio.jasyptspringboot.properties;
+
+import org.jasypt.encryption.StringEncryptor;
+
+public interface PropertyFinder {
+    /**
+     * Does this environment value represent an encrypted value that we are able to decrypt>
+     * @param stringValue Value from the environment
+     * @return true if recognised as a value that we can {@link PropertyFinder#decrypt(String, StringEncryptor)}
+     */
+    boolean isEncryptedValue(String stringValue);
+
+    /**
+     * Decrypt encodedValue using provided encryptor.
+     *
+     * @param encodedValue The entire value from the environment, including the ENC() wrapper, or whatever wrapper satisfies the {@link PropertyFinder#isEncryptedValue(String)} condition for this implementation.
+     * @param encryptor The configured StringEncryptor
+     * @return Decrypted value, or implementation-specific value or exception on null or decryption failure
+     */
+    String decrypt(final String encodedValue, final StringEncryptor encryptor);
+}

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/wrapper/EncryptableEnumerablePropertySourceWrapper.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/wrapper/EncryptableEnumerablePropertySourceWrapper.java
@@ -1,7 +1,7 @@
 package com.ulisesbocchio.jasyptspringboot.wrapper;
 
 import com.ulisesbocchio.jasyptspringboot.EncryptablePropertySource;
-
+import com.ulisesbocchio.jasyptspringboot.properties.PropertyFinder;
 import org.jasypt.encryption.StringEncryptor;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.util.Assert;
@@ -12,13 +12,16 @@ import org.springframework.util.Assert;
 public class EncryptableEnumerablePropertySourceWrapper<T> extends EnumerablePropertySource<T> implements EncryptablePropertySource<T> {
     private final EnumerablePropertySource<T> delegate;
     private final StringEncryptor encryptor;
+    private final PropertyFinder propertyFinder;
 
-    public EncryptableEnumerablePropertySourceWrapper(EnumerablePropertySource<T> delegate, StringEncryptor encryptor) {
+    public EncryptableEnumerablePropertySourceWrapper(EnumerablePropertySource<T> delegate, StringEncryptor encryptor, PropertyFinder propertyFinder) {
         super(delegate.getName(), delegate.getSource());
         Assert.notNull(delegate, "PropertySource delegate cannot be null");
         Assert.notNull(encryptor, "StringEncryptor cannot be null");
+        Assert.notNull(propertyFinder, "PropertyFinder cannot be null");
         this.delegate = delegate;
         this.encryptor = encryptor;
+        this.propertyFinder = propertyFinder;
     }
 
     @Override
@@ -29,5 +32,15 @@ public class EncryptableEnumerablePropertySourceWrapper<T> extends EnumerablePro
     @Override
     public String[] getPropertyNames() {
         return delegate.getPropertyNames();
+    }
+
+    @Override
+    public boolean isEncryptedValue(String stringValue) {
+        return propertyFinder.isEncryptedValue(stringValue);
+    }
+
+    @Override
+    public String decrypt(String encodedValue, StringEncryptor encryptor) {
+        return propertyFinder.decrypt(encodedValue, encryptor);
     }
 }

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/wrapper/EncryptableMapPropertySourceWrapper.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/wrapper/EncryptableMapPropertySourceWrapper.java
@@ -1,7 +1,7 @@
 package com.ulisesbocchio.jasyptspringboot.wrapper;
 
 import com.ulisesbocchio.jasyptspringboot.EncryptablePropertySource;
-
+import com.ulisesbocchio.jasyptspringboot.properties.PropertyFinder;
 import org.jasypt.encryption.StringEncryptor;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.util.Assert;
@@ -13,18 +13,31 @@ import java.util.Map;
  */
 public class EncryptableMapPropertySourceWrapper extends MapPropertySource implements EncryptablePropertySource<Map<String, Object>> {
     private final StringEncryptor encryptor;
-    private MapPropertySource delegate;
+    private final MapPropertySource delegate;
+    private final PropertyFinder propertyFinder;
 
-    public EncryptableMapPropertySourceWrapper(MapPropertySource delegate, StringEncryptor encryptor) {
+    public EncryptableMapPropertySourceWrapper(MapPropertySource delegate, StringEncryptor encryptor, PropertyFinder propertyFinder) {
         super(delegate.getName(), delegate.getSource());
         Assert.notNull(delegate, "PropertySource delegate cannot be null");
         Assert.notNull(encryptor, "StringEncryptor cannot be null");
+        Assert.notNull(propertyFinder, "PropertyFinder cannot be null");
         this.encryptor = encryptor;
         this.delegate = delegate;
+        this.propertyFinder = propertyFinder;
     }
 
     @Override
     public Object getProperty(String name) {
         return getProperty(encryptor, delegate, name);
+    }
+
+    @Override
+    public boolean isEncryptedValue(String stringValue) {
+        return propertyFinder.isEncryptedValue(stringValue);
+    }
+
+    @Override
+    public String decrypt(String encodedValue, StringEncryptor encryptor) {
+        return propertyFinder.decrypt(encodedValue, encryptor);
     }
 }

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/wrapper/EncryptablePropertySourceWrapper.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/wrapper/EncryptablePropertySourceWrapper.java
@@ -1,9 +1,8 @@
 package com.ulisesbocchio.jasyptspringboot.wrapper;
 
 import com.ulisesbocchio.jasyptspringboot.EncryptablePropertySource;
-
+import com.ulisesbocchio.jasyptspringboot.properties.PropertyFinder;
 import org.jasypt.encryption.StringEncryptor;
-import org.jasypt.properties.PropertyValueEncryptionUtils;
 import org.springframework.core.env.PropertySource;
 import org.springframework.util.Assert;
 
@@ -18,17 +17,31 @@ import org.springframework.util.Assert;
 public class EncryptablePropertySourceWrapper<T> extends PropertySource<T> implements EncryptablePropertySource<T> {
     private final PropertySource<T> delegate;
     private final StringEncryptor encryptor;
+    private final PropertyFinder propertyFinder;
 
-    public EncryptablePropertySourceWrapper(PropertySource<T> delegate, StringEncryptor encryptor) {
+    public EncryptablePropertySourceWrapper(PropertySource<T> delegate, StringEncryptor encryptor, PropertyFinder propertyFinder) {
         super(delegate.getName(), delegate.getSource());
         Assert.notNull(delegate, "PropertySource delegate cannot be null");
         Assert.notNull(encryptor, "StringEncryptor cannot be null");
+        Assert.notNull(propertyFinder, "PropertyFinder cannot be null");
         this.delegate = delegate;
         this.encryptor = encryptor;
+        this.propertyFinder = propertyFinder;
     }
 
     @Override
     public Object getProperty(String name) {
         return getProperty(encryptor, delegate, name);
     }
+
+    @Override
+    public boolean isEncryptedValue(String stringValue) {
+        return propertyFinder.isEncryptedValue(stringValue);
+    }
+
+    @Override
+    public String decrypt(String encodedValue, StringEncryptor encryptor) {
+        return propertyFinder.decrypt(encodedValue, encryptor);
+    }
+
 }


### PR DESCRIPTION
We have set of pre-existing encrypted properties that utilise a different set of delimiters.  These can't be changed as they are shared with other projects.

I have created a new interface that can be implemented to detect other encrypted property delimiters and provide an entry point to extract and decrypt the enclosed value.  A default implementation is provided that delegates to Jasypt as currently.

Users can provide their own implementation in exactly the same way they can provide their own StringEncryptor subclass, including customising the bean name.

I've refactored the bean name placeholder logic into its own class now that it is used for two different beans.
Added check to only manipulate bean names with placeholders that we care about.

I have updated the README with details of the customisation options and a sample PropertyFinder subclass.

I hope this is useful to others who may need to integrate with existing encrypted properties, and thanks for creating this library.