### PR TITLE
Default to NULL for Provider Name so default JDK provider is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Use one of the following 3 methods (briefly explained above):
     <dependency>
             <groupId>com.github.ulisesbocchio</groupId>
             <artifactId>jasypt-spring-boot-starter</artifactId>
-            <version>1.2</version>
+            <version>1.5-java7</version>
     </dependency>
 	```
 2. IF you don't use `@SpringBootApplication` or `@EnableAutoConfiguration` Auto Configuration annotations then add this dependency to your project and encryptable properties will be enabled across the entire Spring Environment (This means any system property, environment property, command line argument, application.properties, yaml properties, and any other custom property sources can contain encrypted properties):
@@ -31,7 +31,7 @@ Use one of the following 3 methods (briefly explained above):
     <dependency>
             <groupId>com.github.ulisesbocchio</groupId>
             <artifactId>jasypt-spring-boot</artifactId>
-            <version>1.2</version>
+            <version>1.5-java7</version>
     </dependency>
 	```
 
@@ -108,7 +108,7 @@ Jasypt uses an `StringEncryptor` to decrypt properties. For all 3 methods, if no
       <tr>
           <td>jasypt.encryptor.poolSize</td><td>False</td><td>1</td>
       </tr><tr>
-          <td>jasypt.encryptor.providerName</td><td>False</td><td>SunJCE</td>
+          <td>jasypt.encryptor.providerName</td><td>False</td><td><code>-</code> - the default JVM provider will be used</td>
       </tr>
       <tr>
           <td>jasypt.encryptor.saltGeneratorClassname</td><td>False</td><td>org.jasypt.salt.RandomSaltGenerator</td>

--- a/jasypt-spring-boot-demo/src/main/resources/encrypted.properties
+++ b/jasypt-spring-boot-demo/src/main/resources/encrypted.properties
@@ -4,6 +4,6 @@ secret.property=ENC(nrmZtkF7T0kjG/VodDvBw93Ct8EgjCA+)
 #jasypt.encryptor.algorithm=PBEWithMD5AndDES
 #jasypt.encryptor.keyObtentionIterations=1000
 #jasypt.encryptor.poolSize=1
-#jasypt.encryptor.providerName=SunJCE
+#jasypt.encryptor.providerName= #default JVM provider will be used
 #jasypt.encryptor.saltGeneratorClassname=org.jasypt.salt.RandomSaltGenerator
 #jasypt.encryptor.stringOutputType=base64

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/EnableEncryptablePropertySourcesConfiguration.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/EnableEncryptablePropertySourcesConfiguration.java
@@ -36,7 +36,7 @@ import org.springframework.core.env.PropertySource;
  *     <tr>
  *         <td>jasypt.encryptor.poolSize</td><td>False</td><td>1</td>
  *     </tr><tr>
- *         <td>jasypt.encryptor.providerName</td><td>False</td><td>SunJCE</td>
+ *         <td>jasypt.encryptor.providerName</td><td>False</td><td>{@code null} - the default JVM provider will be used</td>
  *     </tr>
  *     <tr>
  *         <td>jasypt.encryptor.saltGeneratorClassname</td><td>False</td><td>org.jasypt.salt.RandomSaltGenerator</td>

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/StringEncryptorConfiguration.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/StringEncryptorConfiguration.java
@@ -30,7 +30,8 @@ public class StringEncryptorConfiguration {
             config.setAlgorithm(getProperty(environment, "jasypt.encryptor.algorithm", "PBEWithMD5AndDES"));
             config.setKeyObtentionIterations(getProperty(environment, "jasypt.encryptor.keyObtentionIterations", "1000"));
             config.setPoolSize(getProperty(environment, "jasypt.encryptor.poolSize", "1"));
-            config.setProviderName(getProperty(environment, "jasypt.encryptor.providerName", "SunJCE"));
+            // according Jasypt documentation, if no provider name is explicitly set, the default JVM provider will be used.
+            config.setProviderName(getProperty(environment, "jasypt.encryptor.providerName", null));
             config.setSaltGeneratorClassName(getProperty(environment, "jasypt.encryptor.saltGeneratorClassname", "org.jasypt.salt.RandomSaltGenerator"));
             config.setStringOutputType(getProperty(environment, "jasypt.encryptor.stringOutputType", "base64"));
             encryptor.setConfig(config);


### PR DESCRIPTION
We support Jasypt default configuration of security provider if not specified. This is backport of https://github.com/ulisesbocchio/jasypt-spring-boot/commit/31cf4f6b2d2a8c4ab0632f7a765badf22828330b (#40) to version for Java7.

It is possible to merge and release that?

Issue: #40