### PR TITLE
Bootstrapping Jasypt for spring-cloud environments.

### DIFF
--- a/jasypt-spring-boot-starter/pom.xml
+++ b/jasypt-spring-boot-starter/pom.xml
@@ -22,5 +22,20 @@
             <artifactId>spring-boot-starter</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-context</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/jasypt-spring-boot-starter/src/main/java/com/ulisesbocchio/jasyptspringboot/JasyptSpringBootAutoConfiguration.java
+++ b/jasypt-spring-boot-starter/src/main/java/com/ulisesbocchio/jasyptspringboot/JasyptSpringBootAutoConfiguration.java
@@ -1,7 +1,9 @@
 package com.ulisesbocchio.jasyptspringboot;
 
+import com.ulisesbocchio.jasyptspringboot.configuration.EnableEncryptablePropertiesBeanFactoryPostProcessor;
 import com.ulisesbocchio.jasyptspringboot.configuration.EnableEncryptablePropertiesConfiguration;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -9,6 +11,7 @@ import org.springframework.context.annotation.Import;
  * @author Ulises Bocchio
  */
 @Configuration
+@ConditionalOnMissingBean(EnableEncryptablePropertiesBeanFactoryPostProcessor.class)
 @Import(EnableEncryptablePropertiesConfiguration.class)
 public class JasyptSpringBootAutoConfiguration {
 }

--- a/jasypt-spring-boot-starter/src/main/java/com/ulisesbocchio/jasyptspringboot/JasyptSpringCloudBootstrapConfiguration.java
+++ b/jasypt-spring-boot-starter/src/main/java/com/ulisesbocchio/jasyptspringboot/JasyptSpringCloudBootstrapConfiguration.java
@@ -1,0 +1,30 @@
+package com.ulisesbocchio.jasyptspringboot;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import com.ulisesbocchio.jasyptspringboot.configuration.EnableEncryptablePropertiesConfiguration;
+
+/**
+ * Bootstrap configuration applicable only in spring-cloud environments. Can
+ * be explicitly turned-off by <code>jasypt.encryptor.bootstrap=false</code>
+ * configuration (in bootstrap.properties or as a command line argument) in that case
+ * Jasypt will be auto-configured as usual.
+ * 
+ * @author Fahim Farook
+ *
+ */
+@Configuration
+@ConditionalOnClass(name = "org.springframework.cloud.bootstrap.BootstrapApplicationListener")
+@ConditionalOnProperty(name = "spring.cloud.bootstrap.enabled", havingValue = "true", matchIfMissing = true)
+public class JasyptSpringCloudBootstrapConfiguration {
+
+	@Configuration
+	@ConditionalOnProperty(name = "jasypt.encryptor.bootstrap", havingValue = "true", matchIfMissing = true)
+	@Import(EnableEncryptablePropertiesConfiguration.class)
+	protected static class BootstrappingEncryptablePropertiesConfiguration {
+
+	}
+}

--- a/jasypt-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/jasypt-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.ulisesbocchio.jasyptspringboot.JasyptSpringBootAutoConfiguration
+
+org.springframework.cloud.bootstrap.BootstrapConfiguration=\
+com.ulisesbocchio.jasyptspringboot.JasyptSpringCloudBootstrapConfiguration

--- a/jasypt-spring-boot-starter/src/test/java/com/ulisesbocchio/jasyptspringboot/BootstrappingJasyptConfigurationTest.java
+++ b/jasypt-spring-boot-starter/src/test/java/com/ulisesbocchio/jasyptspringboot/BootstrappingJasyptConfigurationTest.java
@@ -1,0 +1,126 @@
+package com.ulisesbocchio.jasyptspringboot;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.cloud.bootstrap.BootstrapApplicationListener;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+import com.ulisesbocchio.jasyptspringboot.configuration.EnableEncryptablePropertiesBeanFactoryPostProcessor;
+
+/**
+ * @author Fahim Farook
+ *
+ */
+public class BootstrappingJasyptConfigurationTest {
+	
+	private ConfigurableApplicationContext context;
+
+	@After
+	public void after() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+	
+	/*
+	 * This is the real issue being addressed in here in JasyptSpringCloudBootstrapConfiguration.
+	 */
+	@Test
+	public void issue_notDecryptedDuringBoostrapPhase() {
+		// making spring.cloud.bootstrap.enabled=true in order to bootstrap the application.
+		// making jasypt.encryptor.bootstrap=false otherwise JasyptSpringCloudBootstrapConfiguration becomes active.
+		startWith(new BaseBootstrappingTestListener() {
+			
+			@Override
+			public void onApplicationEvent(final ApplicationEnvironmentPreparedEvent event) {
+				assertFalse("ENC() value is not decrypted during bootstrap phase",
+						event.getEnvironment().getProperty("spring.cloud.config.server.svn.password").equals("mypassword"));
+			}
+		}, "--spring.cloud.bootstrap.enabled=true", "--jasypt.encryptor.bootstrap=false");
+		
+		// to get codacy to pass.
+		assertNotNull(this.context.getBean(EnableEncryptablePropertiesBeanFactoryPostProcessor.class));
+	}
+	
+	@Test
+	public void fix_decryptedDuringBoostrapPhase() {
+		// making spring.cloud.bootstrap.enabled=true in order to bootstrap the application.
+		// making jasypt.encryptor.bootstrap=true in order to bootstrap Jasypt.
+		startWith(new BaseBootstrappingTestListener() {
+			
+			@Override
+			public void onApplicationEvent(final ApplicationEnvironmentPreparedEvent event) {
+				assertTrue("ENC() value is decrypted during bootstrap phase",
+						event.getEnvironment().getProperty("spring.cloud.config.server.svn.password").equals("mypassword"));
+			}
+		}, "--spring.cloud.bootstrap.enabled=true", "--jasypt.encryptor.bootstrap=true");
+		
+		// to get codacy to pass.
+		assertNotNull(this.context.getBean(EnableEncryptablePropertiesBeanFactoryPostProcessor.class));
+	}
+	
+	@Test
+	public void encryptableBFPPBeanCreatedWhenBoostrapTrue() {
+		startWith(null, "--spring.cloud.bootstrap.enabled=true");
+		assertNotNull("EnableEncryptablePropertiesBeanFactoryPostProcessor not created when spring.cloud.bootstrap.enabled=true", 
+				this.context.getBean(EnableEncryptablePropertiesBeanFactoryPostProcessor.class));
+	}
+	
+	@Test
+	public void encryptableBFPPBeanCreatedWhenBoostrapFalse() {
+		startWith(null, "--spring.cloud.bootstrap.enabled=false");
+		assertNotNull("EnableEncryptablePropertiesBeanFactoryPostProcessor not created when spring.cloud.bootstrap.enabled=false", 
+				this.context.getBean(EnableEncryptablePropertiesBeanFactoryPostProcessor.class));
+	}
+	
+	@SuppressWarnings("rawtypes")
+	private void startWith(final ApplicationListener listener, final String... args) {
+		try {					
+			final SpringApplicationBuilder builder = new SpringApplicationBuilder(BootstrapConfig.class)
+					.profiles("subversion")
+					.properties("server.port=0")
+					.web(true);
+			
+			if (listener != null) {
+				builder.listeners(listener);
+			}
+						
+			this.context = builder.run(args);
+		} catch (final Exception e) {
+			throw new IllegalStateException(e);
+		}
+	}
+	
+	
+	@Configuration
+	@EnableAutoConfiguration
+	static class BootstrapConfig {
+
+	}
+	
+	static abstract class BaseBootstrappingTestListener
+			implements ApplicationListener<ApplicationEnvironmentPreparedEvent>, Ordered {
+
+		@Override
+		public int getOrder() {
+			// order should be greater than
+			// BootstrapApplicationListener.DEFAULT_ORDER - so that this
+			// listener is invoked after BootstrapApplicationListener, otherwise
+			// bootstrap.propertis will not have been read. This is required
+			// since encrypted text (i.e.
+			// passwords) could be configured in bootstrap.properties.
+			return BootstrapApplicationListener.DEFAULT_ORDER + 1;
+		}
+	}
+
+}

--- a/jasypt-spring-boot-starter/src/test/resources/bootstrap.properties
+++ b/jasypt-spring-boot-starter/src/test/resources/bootstrap.properties
@@ -1,0 +1,10 @@
+#spring.cloud.config.server.bootstrap=true
+spring.application.name=config-server
+
+spring.cloud.config.server.svn.username=myusername
+spring.cloud.config.server.svn.password=ENC(GarNzpLDDoIJ3Y5lDabAllQuV74tNFbj)
+
+jasypt.encryptor.algorithm=PBEWithMD5AndDES
+jasypt.encryptor.password=passphrase
+
+spring.profiles.active=subversion

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <spring.boot.version>1.5.4.RELEASE</spring.boot.version>
+        <spring.cloud.version>Dalston.SR4</spring.cloud.version>
         <jasypt.version>1.9.2</jasypt.version>
         <maven.compiler.version>3.6.1</maven.compiler.version>
         <start-class>Application</start-class>
@@ -177,6 +178,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>		
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring.cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Spring cloud defines a **[Bootstrap phase](http://cloud.spring.io/spring-cloud-static/spring-cloud.html#_the_bootstrap_application_context)** wherein it creates a context from configurations in boostrap.properties (or .yml) files. However it fails if Jasypt is used to decrypt encrypted text in boostrap.properties.
<p>
Consider the following scenario where the [config-server itself is bootstrapped](https://cloud.spring.io/spring-cloud-config/multi/multi__embedding_the_config_server.html) - so that the config-server is trying to pull configurations from config-repo during the bootstrap phase. However the password for config-repo is encrypted with Jasypt, but Jasypt decrypts the properties at a later stage only (after boostrap phase). 

```
spring.cloud.config.server.bootstrap=true
spring.application.name=config-server

spring.cloud.config.server.git.uri=https://bitbucket.org/fahim-experiment/config-repo

spring.cloud.config.server.git.username=myusername@somewhere.com
spring.cloud.config.server.git.password=ENC(GarNzpLDDoIJ3Y5lDabAllQuV74tNFbj)

jasypt.encryptor.algorithm=PBEWithMD5AndDES
jasypt.encryptor.password=passphrase
```

As a solution, Jasypt can be bootstrapped in a spring-cloud based application, so that encrypted text will have decrypted by the time config-server is trying to pull from config-repo. 

PoC to replicate the issue [here](https://github.com/fahimfarookme/jasypt-bootstrap-issue/tree/master/issue) and the solution [here](https://github.com/fahimfarookme/jasypt-bootstrap-issue/tree/master/fix).