### PR TITLE
Fix #96: Forked Jasypt to allow Java8+ higher encryption levels.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,16 @@ hs_err_pid*
 **/target/
 *.iml
 .DS_Store
+
+# Eclipse IDE support files
+.classpath
+.settings
+.project
+.checkstyle
+.factorypath
+.tern-project
+target
+*.?ar
+*.iml
+*.ipr
+*.iws

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ Jasypt uses an `StringEncryptor` to decrypt properties. For all 3 methods, if no
           <td>jasypt.encryptor.saltGeneratorClassname</td><td>False</td><td>org.jasypt.salt.RandomSaltGenerator</td>
       </tr>
       <tr>
+          <td>jasypt.encryptor.ivGeneratorClassname</td><td>False</td><td>org.jasypt.salt.NoOpIVGenerator</td>
+      </tr>
+      <tr>
           <td>jasypt.encryptor.stringOutputType</td><td>False</td><td>base64</td>
       </tr>
       <tr>
@@ -186,6 +189,8 @@ Jasypt uses an `StringEncryptor` to decrypt properties. For all 3 methods, if no
 The only property required is the encryption password, the rest could be left to use default values. While all this properties could be declared in a properties file, the encryptor password should not be stored in a property file, it should rather be passed as system property, command line argument, or environment variable and as far as its name is `jasypt.encryptor.password` it'll work.<br/>
 
 The last property, `jasypt.encryptor.proxyPropertySources` is used to indicate `jasyp-spring-boot` how property values are going to be intercepted for decryption. The default value, `false` uses custom wrapper implementations of `PropertySource`, `EnumerablePropertySource`, and `MapPropertySource`. When `true` is specified for this property, the interception mechanism will use CGLib proxies on each specific `PropertySource` implementation. This may be useful on some scenarios where the type of the original `PropertySource` must be preserved. 
+
+The property `jasypt.encryptor.ivGeneratorClassname` defaults to NoOpIVGenerator for backwards compatibility. However, if you would like to use the newer algorithms in Java 8+ (e.g. PBEWITHHMACSHA512ANDAES_256) you must set this value to `org.jasypt.salt.RandomIVGenerator`.
 
 ## <a name="customEncryptor"></a>Use you own Custom Encryptor
 For custom configuration of the encryptor and the source of the encryptor password you can always define your own StringEncryptor bean in your Spring Context, and the default encryptor will be ignored. For instance:
@@ -201,6 +206,7 @@ For custom configuration of the encryptor and the source of the encryptor passwo
         config.setPoolSize("1");
         config.setProviderName("SunJCE");
         config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        config.setIvGeneratorClassName("org.jasypt.salt.NoOpIVGenerator");
         config.setStringOutputType("base64");
         encryptor.setConfig(config);
         return encryptor;
@@ -302,6 +308,7 @@ Example:
             config.setPoolSize(1);
             config.setProviderName("SunJCE");
             config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+            config.setIvGeneratorClassName("org.jasypt.salt.NoOpIVGenerator");
             config.setStringOutputType("base64");
             encryptor.setConfig(config);
         }

--- a/jasypt-spring-boot-starter/src/main/java/com/ulisesbocchio/jasyptspringboot/JasyptSpringBootAutoConfiguration.java
+++ b/jasypt-spring-boot-starter/src/main/java/com/ulisesbocchio/jasyptspringboot/JasyptSpringBootAutoConfiguration.java
@@ -1,9 +1,7 @@
 package com.ulisesbocchio.jasyptspringboot;
 
-import com.ulisesbocchio.jasyptspringboot.configuration.EnableEncryptablePropertiesBeanFactoryPostProcessor;
 import com.ulisesbocchio.jasyptspringboot.configuration.EnableEncryptablePropertiesConfiguration;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 

--- a/jasypt-spring-boot-starter/src/test/resources/bootstrap.properties
+++ b/jasypt-spring-boot-starter/src/test/resources/bootstrap.properties
@@ -2,9 +2,10 @@
 spring.application.name=config-server
 
 spring.cloud.config.server.svn.username=myusername
-spring.cloud.config.server.svn.password=ENC(GarNzpLDDoIJ3Y5lDabAllQuV74tNFbj)
+spring.cloud.config.server.svn.password=ENC(pCRvr+EmDC1DjSjRisfBpPOHWBEBLMiDtcO9KIhZeKOcfYkn2wdPz4TwdE1zlxTl)
 
-jasypt.encryptor.algorithm=PBEWithMD5AndDES
+jasypt.encryptor.algorithm=PBEWITHHMACSHA512ANDAES_256
 jasypt.encryptor.password=passphrase
+jasypt.encryptor.ivGeneratorClassname=org.jasypt.salt.RandomIVGenerator
 
 spring.profiles.active=subversion

--- a/jasypt-spring-boot/pom.xml
+++ b/jasypt-spring-boot/pom.xml
@@ -15,7 +15,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jasypt</groupId>
+            <groupId>com.melloware</groupId>
             <artifactId>jasypt</artifactId>
         </dependency>
         <dependency>
@@ -38,11 +38,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <!--<dependency>-->
-            <!--<groupId>org.springframework.boot</groupId>-->
-            <!--<artifactId>spring-boot-configuration-processor</artifactId>-->
-            <!--<optional>true</optional>-->
-        <!--</dependency>-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/EnableEncryptablePropertiesConfiguration.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/EnableEncryptablePropertiesConfiguration.java
@@ -43,6 +43,9 @@ import org.springframework.core.env.PropertySource;
  *         <td>jasypt.encryptor.saltGeneratorClassname</td><td>False</td><td>org.jasypt.salt.RandomSaltGenerator</td>
  *     </tr>
  *     <tr>
+ *         <td>jasypt.encryptor.ivGeneratorClassname</td><td>False</td><td>org.jasypt.salt.NoOpIVGenerator</td>
+ *     </tr>
+ *     <tr>
  *         <td>jasypt.encryptor.stringOutputType</td><td>False</td><td>base64</td>
  *     </tr>
  * </table>
@@ -58,14 +61,14 @@ import org.springframework.core.env.PropertySource;
 public class EnableEncryptablePropertiesConfiguration implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
     @Bean
-    public static EnableEncryptablePropertiesBeanFactoryPostProcessor enableEncryptablePropertySourcesPostProcessor(ConfigurableEnvironment environment) {
-        boolean proxyPropertySources = environment.getProperty("jasypt.encryptor.proxyPropertySources", Boolean.TYPE, false);
-        InterceptionMode interceptionMode = proxyPropertySources ? InterceptionMode.PROXY : InterceptionMode.WRAPPER;
+    public static EnableEncryptablePropertiesBeanFactoryPostProcessor enableEncryptablePropertySourcesPostProcessor(final ConfigurableEnvironment environment) {
+        final boolean proxyPropertySources = environment.getProperty("jasypt.encryptor.proxyPropertySources", Boolean.TYPE, false);
+        final InterceptionMode interceptionMode = proxyPropertySources ? InterceptionMode.PROXY : InterceptionMode.WRAPPER;
         return new EnableEncryptablePropertiesBeanFactoryPostProcessor(environment, interceptionMode);
     }
 
     @Override
-    public void initialize(ConfigurableApplicationContext applicationContext) {
+    public void initialize(final ConfigurableApplicationContext applicationContext) {
         log.info("Bootstraping jasypt-string-boot auto configuration in context: {}", applicationContext.getId());
     }
 }

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/EncryptablePropertyResolverConfiguration.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/EncryptablePropertyResolverConfiguration.java
@@ -11,7 +11,6 @@ import com.ulisesbocchio.jasyptspringboot.properties.JasyptEncryptorConfiguratio
 import com.ulisesbocchio.jasyptspringboot.properties.JasyptEncryptorConfigurationProperties.PropertyConfigurationProperties.FilterConfigurationProperties;
 import com.ulisesbocchio.jasyptspringboot.resolver.DefaultLazyPropertyResolver;
 import com.ulisesbocchio.jasyptspringboot.util.Singleton;
-import lombok.extern.slf4j.Slf4j;
 import org.jasypt.encryption.StringEncryptor;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -39,7 +38,6 @@ import java.lang.annotation.Annotation;
  * @author Ulises Bocchio
  */
 @Configuration
-@Slf4j
 public class EncryptablePropertyResolverConfiguration {
 
     private static final String ENCRYPTOR_BEAN_PLACEHOLDER = "${jasypt.encryptor.bean:jasyptStringEncryptor}";
@@ -54,40 +52,45 @@ public class EncryptablePropertyResolverConfiguration {
     static final String FILTER_BEAN_NAME = "lazyEncryptablePropertyFilter";
 
     @Bean
-    public EnvCopy envCopy(ConfigurableEnvironment environment) {
+    public EnvCopy envCopy(final ConfigurableEnvironment environment) {
         return new EnvCopy(environment);
     }
 
     @Bean(name = ENCRYPTOR_BEAN_NAME)
-    public StringEncryptor stringEncryptor(@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") EnvCopy envCopy, BeanFactory bf) {
-        String customEncryptorBeanName = envCopy.get().resolveRequiredPlaceholders(ENCRYPTOR_BEAN_PLACEHOLDER);
+    public StringEncryptor stringEncryptor(
+                @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") final EnvCopy envCopy,
+                final BeanFactory bf) {
+        final String customEncryptorBeanName = envCopy.get().resolveRequiredPlaceholders(ENCRYPTOR_BEAN_PLACEHOLDER);
         return new DefaultLazyEncryptor(envCopy.get(), customEncryptorBeanName, bf);
     }
 
     @Bean(name = DETECTOR_BEAN_NAME)
-    public EncryptablePropertyDetector encryptablePropertyDetector(@SuppressWarnings({"SpringJavaInjectionPointsAutowiringInspection"}) EnvCopy envCopy, BeanFactory bf) {
-        String prefix = envCopy.get().resolveRequiredPlaceholders("${jasypt.encryptor.property.prefix:ENC(}");
-        String suffix = envCopy.get().resolveRequiredPlaceholders("${jasypt.encryptor.property.suffix:)}");
-        String customDetectorBeanName = envCopy.get().resolveRequiredPlaceholders(DETECTOR_BEAN_PLACEHOLDER);
+    public EncryptablePropertyDetector encryptablePropertyDetector(
+                @SuppressWarnings({"SpringJavaInjectionPointsAutowiringInspection"}) final EnvCopy envCopy,
+                final BeanFactory bf) {
+        final String prefix = envCopy.get().resolveRequiredPlaceholders("${jasypt.encryptor.property.prefix:ENC(}");
+        final String suffix = envCopy.get().resolveRequiredPlaceholders("${jasypt.encryptor.property.suffix:)}");
+        final String customDetectorBeanName = envCopy.get().resolveRequiredPlaceholders(DETECTOR_BEAN_PLACEHOLDER);
         return new DefaultLazyPropertyDetector(prefix, suffix, customDetectorBeanName, bf);
     }
 
     @Bean(name = CONFIG_SINGLETON)
-    public Singleton<JasyptEncryptorConfigurationProperties> configProps(@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") EnvCopy envCopy, ConfigurableBeanFactory bf) {
+    public Singleton<JasyptEncryptorConfigurationProperties> configProps(
+                @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") final EnvCopy envCopy,
+                final ConfigurableBeanFactory bf) {
         return new Singleton<>(() -> {
-            BindHandler handler = new IgnoreErrorsBindHandler(BindHandler.DEFAULT);
-            MutablePropertySources propertySources = envCopy.get().getPropertySources();
-            Binder binder = new Binder(ConfigurationPropertySources.from(propertySources),
-                    new PropertySourcesPlaceholdersResolver(propertySources),
-                    ApplicationConversionService.getSharedInstance(),
-                    bf::copyRegisteredEditorsTo);
-            JasyptEncryptorConfigurationProperties config = new JasyptEncryptorConfigurationProperties();
+            final BindHandler handler = new IgnoreErrorsBindHandler(BindHandler.DEFAULT);
+            final MutablePropertySources propertySources = envCopy.get().getPropertySources();
+            final Binder binder = new Binder(ConfigurationPropertySources.from(propertySources),
+                        new PropertySourcesPlaceholdersResolver(propertySources),
+                        ApplicationConversionService.getSharedInstance(), bf::copyRegisteredEditorsTo);
+            final JasyptEncryptorConfigurationProperties config = new JasyptEncryptorConfigurationProperties();
 
-            ResolvableType type = ResolvableType.forClass(JasyptEncryptorConfigurationProperties.class);
-            Annotation annotation = AnnotationUtils.findAnnotation(JasyptEncryptorConfigurationProperties.class, ConfigurationProperties.class);
-            Annotation[] annotations = new Annotation[]{annotation};
-            Bindable<?> target = Bindable.of(type).withExistingValue(config)
-                    .withAnnotations(annotations);
+            final ResolvableType type = ResolvableType.forClass(JasyptEncryptorConfigurationProperties.class);
+            final Annotation annotation = AnnotationUtils.findAnnotation(JasyptEncryptorConfigurationProperties.class,
+                        ConfigurationProperties.class);
+            final Annotation[] annotations = new Annotation[] {annotation};
+            final Bindable<?> target = Bindable.of(type).withExistingValue(config).withAnnotations(annotations);
 
             binder.bind("jasypt.encryptor", target, handler);
             return config;
@@ -96,16 +99,22 @@ public class EncryptablePropertyResolverConfiguration {
 
     @SuppressWarnings("unchecked")
     @Bean(name = FILTER_BEAN_NAME)
-    public EncryptablePropertyFilter encryptablePropertyFilter(@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") EnvCopy envCopy, ConfigurableBeanFactory bf, @Qualifier(CONFIG_SINGLETON) Singleton<JasyptEncryptorConfigurationProperties> configProps) {
-        String customFilterBeanName = envCopy.get().resolveRequiredPlaceholders(FILTER_BEAN_PLACEHOLDER);
-        FilterConfigurationProperties filterConfig = configProps.get().getProperty().getFilter();
-        return new DefaultLazyPropertyFilter(filterConfig.getIncludeSources(), filterConfig.getExcludeSources(), filterConfig.getIncludeNames(), filterConfig.getExcludeNames(), customFilterBeanName, bf);
+    public EncryptablePropertyFilter encryptablePropertyFilter(
+                @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") final EnvCopy envCopy,
+                final ConfigurableBeanFactory bf,
+                @Qualifier(CONFIG_SINGLETON) final Singleton<JasyptEncryptorConfigurationProperties> configProps) {
+        final String customFilterBeanName = envCopy.get().resolveRequiredPlaceholders(FILTER_BEAN_PLACEHOLDER);
+        final FilterConfigurationProperties filterConfig = configProps.get().getProperty().getFilter();
+        return new DefaultLazyPropertyFilter(filterConfig.getIncludeSources(), filterConfig.getExcludeSources(),
+                    filterConfig.getIncludeNames(), filterConfig.getExcludeNames(), customFilterBeanName, bf);
     }
 
-
     @Bean(name = RESOLVER_BEAN_NAME)
-    public EncryptablePropertyResolver encryptablePropertyResolver(@Qualifier(DETECTOR_BEAN_NAME) EncryptablePropertyDetector propertyDetector, @Qualifier(ENCRYPTOR_BEAN_NAME) StringEncryptor encryptor, BeanFactory bf, @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") EnvCopy envCopy) {
-        String customResolverBeanName = envCopy.get().resolveRequiredPlaceholders(RESOLVER_BEAN_PLACEHOLDER);
+    public EncryptablePropertyResolver encryptablePropertyResolver(
+                @Qualifier(DETECTOR_BEAN_NAME) final EncryptablePropertyDetector propertyDetector,
+                @Qualifier(ENCRYPTOR_BEAN_NAME) final StringEncryptor encryptor, final BeanFactory bf,
+                @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") final EnvCopy envCopy) {
+        final String customResolverBeanName = envCopy.get().resolveRequiredPlaceholders(RESOLVER_BEAN_PLACEHOLDER);
         return new DefaultLazyPropertyResolver(propertyDetector, encryptor, customResolverBeanName, bf);
     }
 
@@ -115,10 +124,12 @@ public class EncryptablePropertyResolverConfiguration {
     private static class EnvCopy {
         StandardEnvironment copy;
 
-        EnvCopy(ConfigurableEnvironment environment) {
+        EnvCopy(final ConfigurableEnvironment environment) {
             copy = new StandardEnvironment();
             environment.getPropertySources().forEach(ps -> {
-                PropertySource<?> original = ps instanceof EncryptablePropertySource ? ((EncryptablePropertySource) ps).getDelegate() : ps;
+                final PropertySource<?> original = ps instanceof EncryptablePropertySource
+                            ? ((EncryptablePropertySource) ps).getDelegate()
+                            : ps;
                 copy.getPropertySources().addLast(original);
             });
         }

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/encryptor/DefaultLazyEncryptor.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/encryptor/DefaultLazyEncryptor.java
@@ -24,23 +24,23 @@ public class DefaultLazyEncryptor implements StringEncryptor {
 
     public DefaultLazyEncryptor(final Environment e, final String customEncryptorBeanName, final BeanFactory bf) {
         singleton = new Singleton<>(() ->
-                Optional.of(customEncryptorBeanName)
-                        .filter(bf::containsBean)
-                        .map(name -> (StringEncryptor) bf.getBean(name))
-                        .map(tap(bean -> log.info("Found Custom Encryptor Bean {} with name: {}", bean, customEncryptorBeanName)))
-                        .orElseGet(() -> {
-                            log.info("String Encryptor custom Bean not found with name '{}'. Initializing Default String Encryptor", customEncryptorBeanName);
-                            return createDefault(e);
-                        }));
+        Optional.of(customEncryptorBeanName)
+        .filter(bf::containsBean)
+        .map(name -> (StringEncryptor) bf.getBean(name))
+        .map(tap(bean -> log.info("Found Custom Encryptor Bean {} with name: {}", bean, customEncryptorBeanName)))
+        .orElseGet(() -> {
+            log.info("String Encryptor custom Bean not found with name '{}'. Initializing Default String Encryptor", customEncryptorBeanName);
+            return createDefault(e);
+        }));
     }
 
-    public DefaultLazyEncryptor(Environment e) {
+    public DefaultLazyEncryptor(final Environment e) {
         singleton = new Singleton<>(() -> createDefault(e));
     }
 
-    private StringEncryptor createDefault(Environment e) {
-        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
-        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+    private StringEncryptor createDefault(final Environment e) {
+        final PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        final SimpleStringPBEConfig config = new SimpleStringPBEConfig();
         config.setPassword(getRequiredProperty(e, "jasypt.encryptor.password"));
         config.setAlgorithm(getProperty(e, "jasypt.encryptor.algorithm", "PBEWithMD5AndDES"));
         config.setKeyObtentionIterations(getProperty(e, "jasypt.encryptor.keyObtentionIterations", "1000"));
@@ -48,23 +48,24 @@ public class DefaultLazyEncryptor implements StringEncryptor {
         config.setProviderName(getProperty(e, "jasypt.encryptor.providerName", null));
         config.setProviderClassName(getProperty(e, "jasypt.encryptor.providerClassName", null));
         config.setSaltGeneratorClassName(getProperty(e, "jasypt.encryptor.saltGeneratorClassname", "org.jasypt.salt.RandomSaltGenerator"));
+        config.setIvGeneratorClassName(getProperty(e, "jasypt.encryptor.ivGeneratorClassname", "org.jasypt.salt.NoOpIVGenerator"));
         config.setStringOutputType(getProperty(e, "jasypt.encryptor.stringOutputType", "base64"));
         encryptor.setConfig(config);
         return encryptor;
     }
 
-    private static String getProperty(Environment environment, String key, String defaultValue) {
+    private static String getProperty(final Environment environment, final String key, final String defaultValue) {
         if (!propertyExists(environment, key)) {
             log.info("Encryptor config not found for property {}, using default value: {}", key, defaultValue);
         }
         return environment.getProperty(key, defaultValue);
     }
 
-    private static boolean propertyExists(Environment environment, String key) {
+    private static boolean propertyExists(final Environment environment, final String key) {
         return environment.getProperty(key) != null;
     }
 
-    private static String getRequiredProperty(Environment environment, String key) {
+    private static String getRequiredProperty(final Environment environment, final String key) {
         if (!propertyExists(environment, key)) {
             throw new IllegalStateException(String.format("Required Encryption configuration property missing: %s", key));
         }
@@ -72,12 +73,13 @@ public class DefaultLazyEncryptor implements StringEncryptor {
     }
 
     @Override
-    public String encrypt(String message) {
+    public String encrypt(final String message) {
         return singleton.get().encrypt(message);
     }
 
     @Override
-    public String decrypt(String encryptedMessage) {
+    public String decrypt(final String encryptedMessage) {
         return singleton.get().decrypt(encryptedMessage);
     }
+
 }

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/exception/DecryptionException.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/exception/DecryptionException.java
@@ -4,11 +4,14 @@ package com.ulisesbocchio.jasyptspringboot.exception;
  * @author Ulises Bocchio
  */
 public class DecryptionException extends RuntimeException {
-    public DecryptionException(String message) {
+
+    private static final long serialVersionUID = 1L;
+
+    public DecryptionException(final String message) {
         super(message);
     }
 
-    public DecryptionException(String message, Throwable cause) {
+    public DecryptionException(final String message, final Throwable cause) {
         super(message, cause);
     }
 }

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/properties/JasyptEncryptorConfigurationProperties.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/properties/JasyptEncryptorConfigurationProperties.java
@@ -18,16 +18,14 @@ public class JasyptEncryptorConfigurationProperties {
 
     /**
      * Whether to use JDK/Cglib (depending on classpath availability) proxy with an AOP advice as a decorator for
-     * existing {@link org.springframework.core.env.PropertySource}
-     * or just simply use targeted wrapper Classes.
-     * Default Value is {@code false}.
+     * existing {@link org.springframework.core.env.PropertySource} or just simply use targeted wrapper Classes. Default
+     * Value is {@code false}.
      */
     private Boolean proxyPropertySources = false;
 
     /**
-     * Specify the name of bean to override jasypt-spring-boot's default properties based {@link
-     * org.jasypt.encryption.StringEncryptor}.
-     * Default Value is {@code jasyptStringEncryptor}.
+     * Specify the name of bean to override jasypt-spring-boot's default properties based
+     * {@link org.jasypt.encryption.StringEncryptor}. Default Value is {@code jasyptStringEncryptor}.
      */
     private String bean = "jasyptStringEncryptor";
 
@@ -40,10 +38,8 @@ public class JasyptEncryptorConfigurationProperties {
     private String password;
 
     /**
-     * Encryption/Decryption Algorithm to be used by Jasypt.
-     * For more info on how to get available algorithms visit: <a href="http://www.jasypt.org/cli.html"/>Jasypt CLI
-     * Tools Page</a>.
-     * Default Value is {@code "PBEWithMD5AndDES"}.
+     * Encryption/Decryption Algorithm to be used by Jasypt. For more info on how to get available algorithms visit:
+     * <a href="http://www.jasypt.org/cli.html"/>Jasypt CLI Tools Page</a>. Default Value is {@code "PBEWithMD5AndDES"}.
      *
      * @see org.jasypt.encryption.pbe.PBEStringEncryptor
      * @see org.jasypt.encryption.pbe.config.StringPBEConfig#getAlgorithm()
@@ -51,8 +47,7 @@ public class JasyptEncryptorConfigurationProperties {
     private String algorithm = "PBEWithMD5AndDES";
 
     /**
-     * Number of hashing iterations to obtain the signing key.
-     * Default Value is {@code "1000"}.
+     * Number of hashing iterations to obtain the signing key. Default Value is {@code "1000"}.
      *
      * @see org.jasypt.encryption.pbe.PBEStringEncryptor
      * @see org.jasypt.encryption.pbe.config.StringPBEConfig#getKeyObtentionIterations()
@@ -60,8 +55,7 @@ public class JasyptEncryptorConfigurationProperties {
     private String keyObtentionIterations = "1000";
 
     /**
-     * The size of the pool of encryptors to be created.
-     * Default Value is {@code "1"}.
+     * The size of the pool of encryptors to be created. Default Value is {@code "1"}.
      *
      * @see org.jasypt.encryption.pbe.PBEStringEncryptor
      * @see org.jasypt.encryption.pbe.config.StringPBEConfig#getPoolSize()
@@ -69,9 +63,8 @@ public class JasyptEncryptorConfigurationProperties {
     private String poolSize = "1";
 
     /**
-     * The name of the {@link java.security.Provider} implementation
-     * to be used by the encryptor for obtaining the encryption algorithm.
-     * Default Value is {@code null}.
+     * The name of the {@link java.security.Provider} implementation to be used by the encryptor for obtaining the
+     * encryption algorithm. Default Value is {@code null}.
      *
      * @see org.jasypt.encryption.pbe.PBEStringEncryptor
      * @see org.jasypt.encryption.pbe.config.StringPBEConfig#getProviderName()
@@ -79,9 +72,8 @@ public class JasyptEncryptorConfigurationProperties {
     private String providerName = null;
 
     /**
-     * A {@link org.jasypt.salt.SaltGenerator} implementation to be used by the
-     * encryptor.
-     * Default Value is {@code "org.jasypt.salt.RandomSaltGenerator"}.
+     * A {@link org.jasypt.salt.SaltGenerator} implementation to be used by the encryptor. Default Value is
+     * {@code "org.jasypt.salt.RandomSaltGenerator"}.
      *
      * @see org.jasypt.encryption.pbe.PBEStringEncryptor
      * @see org.jasypt.encryption.pbe.config.StringPBEConfig#getSaltGenerator()
@@ -89,14 +81,22 @@ public class JasyptEncryptorConfigurationProperties {
     private String saltGeneratorClassname = "org.jasypt.salt.RandomSaltGenerator";
 
     /**
-     * Specify the form in which String output will be encoded. {@code "base64"} or {@code "hexadecimal"}.
-     * Default Value is {@code "base64"}.
+     * A {@link org.jasypt.salt.IVGenerator} implementation to be used by the encryptor. Default Value is
+     * {@code "org.jasypt.salt.NoOpIVGenerator"}.
+     *
+     * @see org.jasypt.encryption.pbe.PBEStringEncryptor
+     * @see org.jasypt.encryption.pbe.config.StringPBEConfig#getIVGenerator()
+     */
+    private String ivGeneratorClassname = "org.jasypt.salt.NoOpIVGenerator";
+
+    /**
+     * Specify the form in which String output will be encoded. {@code "base64"} or {@code "hexadecimal"}. Default Value
+     * is {@code "base64"}.
      *
      * @see org.jasypt.encryption.pbe.PBEStringEncryptor
      * @see org.jasypt.encryption.pbe.config.StringPBEConfig#getStringOutputType()
      */
     private String stringOutputType = "base64";
-
 
     @NestedConfigurationProperty
     private PropertyConfigurationProperties property = new PropertyConfigurationProperties();
@@ -105,32 +105,33 @@ public class JasyptEncryptorConfigurationProperties {
     public static class PropertyConfigurationProperties {
 
         /**
-         * Specify the name of the bean to be provided for a custom {@link com.ulisesbocchio.jasyptspringboot.EncryptablePropertyDetector}.
-         * Default value is {@code "encryptablePropertyDetector"}
+         * Specify the name of the bean to be provided for a custom
+         * {@link com.ulisesbocchio.jasyptspringboot.EncryptablePropertyDetector}. Default value is
+         * {@code "encryptablePropertyDetector"}
          */
         private String detectorBean = "encryptablePropertyDetector";
 
         /**
-         * Specify the name of the bean to be provided for a custom {@link com.ulisesbocchio.jasyptspringboot.EncryptablePropertyResolver}.
-         * Default value is {@code "encryptablePropertyResolver"}
+         * Specify the name of the bean to be provided for a custom
+         * {@link com.ulisesbocchio.jasyptspringboot.EncryptablePropertyResolver}. Default value is
+         * {@code "encryptablePropertyResolver"}
          */
         private String resolverBean = "encryptablePropertyResolver";
 
         /**
-         * Specify the name of the bean to be provided for a custom {@link EncryptablePropertyFilter}.
-         * Default value is {@code "encryptablePropertyFilter"}
+         * Specify the name of the bean to be provided for a custom {@link EncryptablePropertyFilter}. Default value is
+         * {@code "encryptablePropertyFilter"}
          */
         private String filterBean = "encryptablePropertyFilter";
 
         /**
-         * Specify a custom {@link String} to identify as prefix of encrypted properties.
-         * Default value is {@code "ENC("}
+         * Specify a custom {@link String} to identify as prefix of encrypted properties. Default value is
+         * {@code "ENC("}
          */
         private String prefix = "ENC(";
 
         /**
-         * Specify a custom {@link String} to identify as suffix of encrypted properties.
-         * Default value is {@code ")"}
+         * Specify a custom {@link String} to identify as suffix of encrypted properties. Default value is {@code ")"}
          */
         private String suffix = ")";
 
@@ -141,14 +142,14 @@ public class JasyptEncryptorConfigurationProperties {
         public static class FilterConfigurationProperties {
 
             /**
-             * Specify the property sources name patterns to be included for decryption by{@link EncryptablePropertyFilter}.
-             * Default value is {@code null}
+             * Specify the property sources name patterns to be included for decryption
+             * by{@link EncryptablePropertyFilter}. Default value is {@code null}
              */
             private List<String> includeSources = null;
 
             /**
-             * Specify the property sources name patterns to be EXCLUDED for decryption by{@link EncryptablePropertyFilter}.
-             * Default value is {@code null}
+             * Specify the property sources name patterns to be EXCLUDED for decryption
+             * by{@link EncryptablePropertyFilter}. Default value is {@code null}
              */
             private List<String> excludeSources = null;
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <java.version>1.8</java.version>
         <spring.boot.version>2.1.0.RELEASE</spring.boot.version>
         <spring.cloud.version>Finchley.RELEASE</spring.cloud.version>
-        <jasypt.version>1.9.2</jasypt.version>
+        <jasypt.version>1.9.4</jasypt.version>
         <maven.compiler.version>3.7.0</maven.compiler.version>
         <start-class>Application</start-class>
     </properties>
@@ -194,7 +194,7 @@
                 <version>${spring.boot.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.jasypt</groupId>
+                <groupId>com.melloware</groupId>
                 <artifactId>jasypt</artifactId>
                 <version>${jasypt.version}</version>
             </dependency>


### PR DESCRIPTION
This PR allows the starter to use the new Java8+ encryption levels.  Out of the box it is 100% backward compatible for previous users because it defaults the IVgenerator to NoOp.
```
jasypt.encryptor.ivGeneratorClassname=org.jasypt.salt.NoOpIVGenerator
```

If you would like to use advance encryption like PBEWITHHMACSHA512ANDAES_256 you must use the RandomIvGenerator like...
```
jasypt.encryptor.algorithm=PBEWITHHMACSHA512ANDAES_256
jasypt.encryptor.ivGeneratorClassname=org.jasypt.salt.RandomIVGenerator
```

Once the Samples project has resolved the H2 DB issue I will repair all of the samples to work as well.

Forked GitHub is here: https://github.com/melloware/jasypt