### PR TITLE
Add OpenJDK version 11 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
+  - openjdk11
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
Travis tests should be run with the current JAVA LTS version.