### PR TITLE
put something space into the bean processing order

### DIFF
--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/EnableEncryptablePropertiesBeanFactoryPostProcessor.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/EnableEncryptablePropertiesBeanFactoryPostProcessor.java
@@ -54,6 +54,6 @@ public class EnableEncryptablePropertiesBeanFactoryPostProcessor implements Bean
 
     @Override
     public int getOrder() {
-        return Ordered.LOWEST_PRECEDENCE;
+        return Ordered.LOWEST_PRECEDENCE - 100;
     }
 }


### PR DESCRIPTION
There are some cases where another post-processors are put into the list, those should have the option of using the encrypted properties as well.