### PR TITLE
Add Maven Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 hs_err_pid*
 
 **/target/
-*.iml
 .DS_Store
 
 # Eclipse IDE support files
@@ -24,6 +23,9 @@ hs_err_pid*
 .tern-project
 target
 *.?ar
-*.iml
 *.ipr
 *.iws
+
+# IntelliJ
+.idea/
+*.iml

--- a/jasypt-maven-plugin/pom.xml
+++ b/jasypt-maven-plugin/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>jasypt-spring-boot-parent</artifactId>
+        <groupId>com.github.ulisesbocchio</groupId>
+        <version>2.1.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jasypt-maven-plugin</artifactId>
+
+
+</project>

--- a/jasypt-maven-plugin/pom.xml
+++ b/jasypt-maven-plugin/pom.xml
@@ -11,6 +11,69 @@
     </parent>
 
     <artifactId>jasypt-maven-plugin</artifactId>
+    <name>Jasypt Maven Plugin</name>
+    <packaging>maven-plugin</packaging>
 
+    <properties>
+        <maven.api.version>2.2.1</maven.api.version>
+        <maven-plugin-annotations.version>3.3</maven-plugin-annotations.version>
+        <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
+    </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.github.ulisesbocchio</groupId>
+            <artifactId>jasypt-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${maven.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>${maven-plugin-annotations.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>${maven-plugin-plugin.version}</version>
+                <configuration>
+                    <goalPrefix>jasypt</goalPrefix>
+                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>mojo-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>help-goal</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/encrypt/EncryptionService.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/encrypt/EncryptionService.java
@@ -1,0 +1,94 @@
+package com.ulisesbocchio.jasyptmavenplugin.encrypt;
+
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.properties.EncryptableProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.regex.Pattern.DOTALL;
+
+/**
+ * A service for encrypting and decrypting Strings.
+ */
+public class EncryptionService {
+  private static final Pattern ENCRYPTED_PATTERN = Pattern.compile("ENC\\((.*?)\\)", DOTALL);
+
+  private static final Pattern DECRYPTED_PATTERN = Pattern.compile("DEC\\((.*?)\\)", DOTALL);
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(EncryptionService.class);
+
+  private final StringEncryptor encryptor;
+
+  public EncryptionService(final StringEncryptor encryptor) {
+    this.encryptor = encryptor;
+  }
+
+  /**
+   * Replace all instance of pattern in the templateText, according to the replacer.
+   * @param templateText the template
+   * @param pattern the pattern to replace
+   * @param replacer the replacement generator
+   * @return the replaced content
+   */
+  private static String replaceAll(
+      final String templateText, final Pattern pattern,
+      final Function<String, String> replacer
+  ) {
+    Matcher matcher = pattern.matcher(templateText);
+    StringBuffer result = new StringBuffer();
+    String replace;
+    while (matcher.find()) {
+      replace = replacer.apply(matcher.group(1));
+      matcher.appendReplacement(result, "");
+      result.append(replace);
+    }
+    matcher.appendTail(result);
+    return result.toString();
+  }
+
+  /**
+   * Execute the supplied mutator on the contents.
+   * @param contents the contents to mutate
+   * @param pattern the pattern to identify placeholders
+   * @param prefix the prefix for the mutated placeholder
+   * @param mutationName the name of the operation
+   * @param mutator the operation
+   * @return the mutated contents
+   */
+  private String run(
+      final String contents, final Pattern pattern, final String prefix,
+      final String mutationName, final Function<String, String> mutator
+  ) {
+    return replaceAll(contents, pattern, matched -> {
+      String mutatedValue = prefix + "(" + mutator.apply(matched) + ")";
+      LOGGER.debug("{} value {} to {}", mutationName, matched, mutatedValue);
+      return mutatedValue;
+    });
+  }
+
+  /**
+   * Decrypt all placeholders in the input.
+   * @param input the string to scan for placeholders and decrypt
+   * @return the input with decrypted placeholders.
+   */
+  public String decrypt(final String input) {
+    return run(input, ENCRYPTED_PATTERN, "DEC", "Decrypted", encryptor::decrypt);
+  }
+
+  /**
+   * Encrypt all placeholders in the input.
+   * @param input the string to scan for placeholders and encrypt
+   * @return the input with encrypted placeholders.
+   */
+  public String encrypt(final String input) {
+    return run(input, DECRYPTED_PATTERN, "ENC", "Encrypted", encryptor::encrypt);
+  }
+
+  public EncryptableProperties getEncryptableProperties() {
+    return new EncryptableProperties(encryptor);
+  }
+}

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/encrypt/EncryptionService.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/encrypt/EncryptionService.java
@@ -13,6 +13,8 @@ import static java.util.regex.Pattern.DOTALL;
 
 /**
  * A service for encrypting and decrypting Strings.
+ *
+ * @author Rupert Madden-Abbott
  */
 public class EncryptionService {
   private static final Pattern ENCRYPTED_PATTERN = Pattern.compile("ENC\\((.*?)\\)", DOTALL);

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/AbstractJasyptMojo.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/AbstractJasyptMojo.java
@@ -19,6 +19,8 @@ import static org.codehaus.plexus.util.FileUtils.removeExtension;
 
 /**
  * A mojo that spins up a Spring Boot application for any encrypt/decrypt function.
+ *
+ * @author Rupert Madden-Abbott
  */
 public abstract class AbstractJasyptMojo extends AbstractMojo {
   /**

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/AbstractJasyptMojo.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/AbstractJasyptMojo.java
@@ -1,0 +1,80 @@
+package com.ulisesbocchio.jasyptmavenplugin.mojo;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import com.ulisesbocchio.jasyptmavenplugin.encrypt.EncryptionService;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.jasypt.encryption.StringEncryptor;
+import org.springframework.boot.Banner;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.Environment;
+
+import static org.codehaus.plexus.util.FileUtils.getExtension;
+import static org.codehaus.plexus.util.FileUtils.removeExtension;
+
+/**
+ * A mojo that spins up a Spring Boot application for any encrypt/decrypt function.
+ */
+public abstract class AbstractJasyptMojo extends AbstractMojo {
+  /**
+   * The path of the file to operate on.
+   */
+  @Parameter(property = "jasypt.plugin.path",
+      defaultValue = "file:src/main/resources/application.properties")
+  private String path = "file:src/main/resources/application.properties";
+
+  @Override
+  public void execute() throws MojoExecutionException {
+    ConfigurableApplicationContext context = new SpringApplicationBuilder()
+        .sources(Application.class)
+        .bannerMode(Banner.Mode.OFF)
+        .run();
+
+    StringEncryptor encryptor = context.getBean(StringEncryptor.class);
+
+    run(new EncryptionService(encryptor), getFullFilePath(context));
+  }
+
+  /**
+   * Run the encryption task.
+   * @param encryptionService the service for encryption
+   * @param fullPath the path to operate on
+   */
+  abstract void run(EncryptionService encryptionService, Path fullPath)
+      throws MojoExecutionException;
+
+  /**
+   * Construct the full file path, relative to the active environment.
+   * @param context the context (for retrieving active environments)
+   * @return the full path
+   * @throws MojoExecutionException if the file does not exist
+   */
+  private Path getFullFilePath(final ApplicationContext context)
+      throws MojoExecutionException {
+    String fullPath = path;
+    Environment env = context.getEnvironment();
+    String[] activeProfiles = env.getActiveProfiles();
+
+    if (activeProfiles.length > 0) {
+      String extension = getExtension(fullPath);
+      String pathWithoutExtension = removeExtension(fullPath);
+
+      fullPath = pathWithoutExtension + "-" + activeProfiles[0];
+
+      if (!extension.isEmpty()) {
+        fullPath += "." + extension;
+      }
+    }
+
+    try {
+      return context.getResource(fullPath).getFile().toPath();
+    } catch (IOException e) {
+      throw new MojoExecutionException("Unable to open configuration file", e);
+    }
+  }
+}

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/Application.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/Application.java
@@ -1,0 +1,12 @@
+package com.ulisesbocchio.jasyptmavenplugin.mojo;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * The main class. Note that location is important, at the root package of this module, so that
+ * the correct spring configuration can be located. No main method is required because this will be
+ * initiated via a Maven Mojo. See {@link AbstractJasyptMojo}.
+ */
+@SpringBootApplication
+public class Application {
+}

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/Application.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/Application.java
@@ -6,6 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * The main class. Note that location is important, at the root package of this module, so that
  * the correct spring configuration can be located. No main method is required because this will be
  * initiated via a Maven Mojo. See {@link AbstractJasyptMojo}.
+ *
+ * @author Rupert Madden-Abbott
  */
 @SpringBootApplication
 public class Application {

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/DecryptMojo.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/DecryptMojo.java
@@ -11,6 +11,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Goal which decrypts demarcated values in properties files.
+ *
+ * @author Rupert Madden-Abbott
  */
 @Mojo(name = "decrypt", defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
 public class DecryptMojo extends AbstractJasyptMojo {

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/DecryptMojo.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/DecryptMojo.java
@@ -1,0 +1,29 @@
+package com.ulisesbocchio.jasyptmavenplugin.mojo;
+
+import java.nio.file.Path;
+
+import com.ulisesbocchio.jasyptmavenplugin.encrypt.EncryptionService;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Goal which decrypts demarcated values in properties files.
+ */
+@Mojo(name = "decrypt", defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
+public class DecryptMojo extends AbstractJasyptMojo {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DecryptMojo.class);
+
+  @Override
+  protected void run(final EncryptionService service, final Path path) throws
+      MojoExecutionException {
+    LOGGER.info("Decrypting file " + path);
+
+    String contents = FileService.read(path);
+    String decryptedContents = service.decrypt(contents);
+
+    LOGGER.info("\n" + decryptedContents);
+  }
+}

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/EncryptMojo.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/EncryptMojo.java
@@ -1,0 +1,29 @@
+package com.ulisesbocchio.jasyptmavenplugin.mojo;
+
+import java.nio.file.Path;
+
+import com.ulisesbocchio.jasyptmavenplugin.encrypt.EncryptionService;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Goal which encrypts demarcated values in properties files.
+ */
+@Mojo(name = "encrypt", defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
+public class EncryptMojo extends AbstractJasyptMojo {
+  private static final Logger LOGGER = LoggerFactory.getLogger(EncryptMojo.class);
+
+  @Override
+  protected void run(final EncryptionService service, final Path path) throws
+      MojoExecutionException {
+    LOGGER.info("Encrypting file " + path);
+
+    String contents = FileService.read(path);
+    String encryptedContents = service.encrypt(contents);
+
+    FileService.write(path, encryptedContents);
+  }
+}

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/EncryptMojo.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/EncryptMojo.java
@@ -11,6 +11,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Goal which encrypts demarcated values in properties files.
+ *
+ * @author Rupert Madden-Abbott
  */
 @Mojo(name = "encrypt", defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
 public class EncryptMojo extends AbstractJasyptMojo {

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/FileService.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/FileService.java
@@ -1,0 +1,53 @@
+package com.ulisesbocchio.jasyptmavenplugin.mojo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * A service for operating on files.
+ */
+public class FileService {
+  /**
+   * Read a file.
+   * @param path the file path
+   * @return the contents.
+   */
+  public static String read(final Path path) throws MojoExecutionException {
+    try {
+      return new String(Files.readAllBytes(path));
+    } catch (IOException e) {
+      throw new MojoExecutionException("Unable to read file " + path, e);
+    }
+  }
+
+  /**
+   * Write to a file.
+   * @param path the file path
+   * @param contents the contents to write
+   */
+  public static void write(final Path path, final String contents) throws MojoExecutionException {
+    try {
+      Files.write(path, contents.getBytes());
+    } catch (IOException e) {
+      throw new MojoExecutionException("Unable to write file " + path, e);
+    }
+  }
+
+  /**
+   * Load a file into properties.
+   * @param path the path
+   * @param properties the properties to mutate
+   */
+  public static void load(final Path path, final Properties properties)
+      throws MojoExecutionException {
+    try {
+      properties.load(Files.newInputStream(path));
+    } catch (IOException e) {
+      throw new MojoExecutionException("Unable to load file " + path, e);
+    }
+  }
+}

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/FileService.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/FileService.java
@@ -9,6 +9,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 
 /**
  * A service for operating on files.
+ *
+ * @author Rupert Madden-Abbott
  */
 public class FileService {
   /**

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/LoadMojo.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/LoadMojo.java
@@ -16,6 +16,8 @@ import org.slf4j.LoggerFactory;
  * The 'load' goal loads and decrypts property files for the supplied environment(s). The properties
  * can then be used in pom.xml configurations as '${something.prop}' for other plugins, e.g. flyway
  * or the mybatis generator.
+ *
+ * @author Rupert Madden-Abbott
  */
 @Mojo(name = "load", defaultPhase = LifecyclePhase.NONE, threadSafe = true)
 public class LoadMojo extends AbstractJasyptMojo {

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/LoadMojo.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/LoadMojo.java
@@ -1,0 +1,57 @@
+package com.ulisesbocchio.jasyptmavenplugin.mojo;
+
+import java.nio.file.Path;
+import java.util.Properties;
+
+import com.ulisesbocchio.jasyptmavenplugin.encrypt.EncryptionService;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The 'load' goal loads and decrypts property files for the supplied environment(s). The properties
+ * can then be used in pom.xml configurations as '${something.prop}' for other plugins, e.g. flyway
+ * or the mybatis generator.
+ */
+@Mojo(name = "load", defaultPhase = LifecyclePhase.NONE, threadSafe = true)
+public class LoadMojo extends AbstractJasyptMojo {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LoadMojo.class);
+
+  /**
+   * Prefix that will be added before name of each property. Can be useful for distinguishing the
+   * source of the properties from other maven properties.
+   */
+  @Parameter(property = "jasypt.plugin.keyPrefix")
+  private String keyPrefix = null;
+
+  @Parameter(defaultValue = "${project}", readonly = true, required = true)
+  private MavenProject project;
+
+  @Override
+  protected void run(final EncryptionService service, final Path path) throws
+      MojoExecutionException {
+    Properties properties = service.getEncryptableProperties();
+    FileService.load(path, properties);
+
+    if (properties.isEmpty()) {
+      LOGGER.info("  No properties found");
+    } else {
+      for (String key : properties.stringPropertyNames()) {
+        LOGGER.info("  Loaded '" + key + "' property");
+      }
+    }
+
+    Properties projectProperties = project.getProperties();
+    for (String key : properties.stringPropertyNames()) {
+      if (keyPrefix != null) {
+        projectProperties.put(keyPrefix + key, properties.get(key));
+      } else {
+        projectProperties.put(key, properties.get(key));
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <modules>
         <module>jasypt-spring-boot</module>
         <module>jasypt-spring-boot-starter</module>
+        <module>jasypt-maven-plugin</module>
     </modules>
 
     <issueManagement>


### PR DESCRIPTION
Hi,

Thanks very much for this useful Spring Boot starter. My company makes extensive use of it to decrypt sensitive properties.

We have created a maven plugin which makes use of this starter. It helps us to create files with encrypted values which this starter then later decrypts at runtime. We find it helpful to share as much code as possible between the plugin and the starter to ensure that configuration options stay in sync.

We also have a decrypt goal (handy for quickly checking what has been encrypted) and a load goal which allows this starter to provide decrypted properties to other Maven plugins, most notably Flyway. Please see the readme changes for full documentation.

I think this plugin is likely to be useful outside of my company so I want to make it open source. I think it makes sense as part of this repository so I would like to see if you are interested in having this merged back upstream initially. If not, I will release it as a separate repository but please let me know if I can make any changes to make merging it possible.