### PR TITLE
Switch to HashMap to avoid concurrency issues.

### DIFF
--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/caching/CachingDelegateEncryptablePropertySource.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/caching/CachingDelegateEncryptablePropertySource.java
@@ -34,13 +34,13 @@ public class CachingDelegateEncryptablePropertySource<T> extends PropertySource<
     public Object getProperty(String name) {
         // Can be called recursively, so, we cannot use computeIfAbsent.
         synchronized (this) {
-            if (cache.containsKey(name)) {
-                return cache.get(name);
-            } else {
+            if (!cache.containsKey(name)) {
                 Object resolved = getProperty(resolver, filter, delegate, name);
-                cache.put(name, resolved);
-                return resolved;
+                if (resolved != null) {
+                    cache.put(name, resolved);
+                }
             }
+            return cache.get(name);
         }
     }
 


### PR DESCRIPTION
GH-131

See: https://bugs.openjdk.java.net/browse/JDK-8206399

And docs from ConcurrentHashMap:

"if the computation detectably attempts a recursive update to this map that would otherwise never complete".

Which it fails to detect, but, recursive computeIfAbsent is not supported.