### PR TITLE
fix: using PriorityOrdered instead of @Order

### DIFF
--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/caching/RefreshScopeRefreshedEventListener.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/caching/RefreshScopeRefreshedEventListener.java
@@ -4,22 +4,24 @@ import com.ulisesbocchio.jasyptspringboot.EncryptablePropertySource;
 import com.ulisesbocchio.jasyptspringboot.EncryptablePropertySourceConverter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
+import org.springframework.core.PriorityOrdered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.*;
 import org.springframework.util.ClassUtils;
 
-@Order(Ordered.HIGHEST_PRECEDENCE)
 @Slf4j
-public class RefreshScopeRefreshedEventListener implements ApplicationListener<ApplicationEvent> {
+public class RefreshScopeRefreshedEventListener implements ApplicationListener<ApplicationEvent>, PriorityOrdered {
 
     public static final String REFRESHED_EVENT_CLASS = "org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent";
     public static final String ENVIRONMENT_EVENT_CLASS = "org.springframework.cloud.context.environment.EnvironmentChangeEvent";
     private final ConfigurableEnvironment environment;
     private final EncryptablePropertySourceConverter converter;
     private Boolean cloudDependencyExists = true;
+    private final int order = Ordered.LOWEST_PRECEDENCE - 100;
 
     public RefreshScopeRefreshedEventListener(ConfigurableEnvironment environment, EncryptablePropertySourceConverter converter) {
         this.environment = environment;
@@ -64,5 +66,10 @@ public class RefreshScopeRefreshedEventListener implements ApplicationListener<A
             EncryptablePropertySource eps = (EncryptablePropertySource) propertySource;
             eps.refresh();
         }
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
     }
 }


### PR DESCRIPTION
In OrderComparator PriorityOrdered always in front of @Order

[OrderComparator.java](https://github.com/spring-projects/spring-framework/blob/b595dc1dfad9db534ca7b9e8f46bb9926b88ab5a/spring-core/src/main/java/org/springframework/core/OrderComparator.java#L76)
```
....
	@Override
	public int compare(@Nullable Object o1, @Nullable Object o2) {
		return doCompare(o1, o2, null);
	}

	private int doCompare(@Nullable Object o1, @Nullable Object o2, @Nullable OrderSourceProvider sourceProvider) {
		boolean p1 = (o1 instanceof PriorityOrdered);
		boolean p2 = (o2 instanceof PriorityOrdered);
		if (p1 && !p2) {
			return -1;
		}
		else if (p2 && !p1) {
			return 1;
		}

		int i1 = getOrder(o1, sourceProvider);
		int i2 = getOrder(o2, sourceProvider);
		return Integer.compare(i1, i2);
	}
....
```