### PR TITLE
fix: PropertySource named 'xxx' does not exist

### DIFF
--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/aop/EncryptableMutablePropertySourcesInterceptor.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/aop/EncryptableMutablePropertySourcesInterceptor.java
@@ -1,15 +1,11 @@
 package com.ulisesbocchio.jasyptspringboot.aop;
 
-import com.ulisesbocchio.jasyptspringboot.EncryptablePropertyFilter;
-import com.ulisesbocchio.jasyptspringboot.EncryptablePropertyResolver;
 import com.ulisesbocchio.jasyptspringboot.EncryptablePropertySourceConverter;
-import com.ulisesbocchio.jasyptspringboot.InterceptionMode;
 import com.ulisesbocchio.jasyptspringboot.configuration.EnvCopy;
+
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.core.env.PropertySource;
-
-import java.util.List;
 
 /**
  * @author Ulises Bocchio
@@ -40,13 +36,16 @@ public class EncryptableMutablePropertySourcesInterceptor implements MethodInter
                 envCopy.get().getPropertySources().addLast((PropertySource<?>) arguments[0]);
                 return invocation.getMethod().invoke(invocation.getThis(), makeEncryptable(arguments[0]));
             case "addBefore":
-                envCopy.get().getPropertySources().addBefore((String) arguments[0], (PropertySource<?>) arguments[1]);
+                final String name1 = (String) arguments[0];
+                envCopy.getPropertySources(name1).addBefore(name1, (PropertySource<?>) arguments[1]);
                 return invocation.getMethod().invoke(invocation.getThis(), arguments[0], makeEncryptable(arguments[1]));
             case "addAfter":
-                envCopy.get().getPropertySources().addAfter((String) arguments[0], (PropertySource<?>) arguments[1]);
+                final String name2 = (String) arguments[0];
+                envCopy.getPropertySources(name2).addAfter(name2, (PropertySource<?>) arguments[1]);
                 return invocation.getMethod().invoke(invocation.getThis(), arguments[0], makeEncryptable(arguments[1]));
             case "replace":
-                envCopy.get().getPropertySources().replace((String) arguments[0], (PropertySource<?>) arguments[1]);
+                final String name3 = (String) arguments[0];
+                envCopy.getPropertySources(name3).replace(name3, (PropertySource<?>) arguments[1]);
                 return invocation.getMethod().invoke(invocation.getThis(), arguments[0], makeEncryptable(arguments[1]));
             default:
                 return invocation.proceed();

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/EnvCopy.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/configuration/EnvCopy.java
@@ -1,9 +1,13 @@
 package com.ulisesbocchio.jasyptspringboot.configuration;
 
 import com.ulisesbocchio.jasyptspringboot.EncryptablePropertySource;
+import com.ulisesbocchio.jasyptspringboot.environment.StandardEncryptableEnvironment;
+import com.ulisesbocchio.jasyptspringboot.environment.StandardEncryptableServletEnvironment;
+
+import org.springframework.core.env.AbstractEnvironment;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
-import org.springframework.core.env.StandardEnvironment;
 
 import java.util.Optional;
 
@@ -11,20 +15,51 @@ import java.util.Optional;
  * Need a copy of the environment without the Enhanced property sources to avoid circular dependencies.
  */
 public class EnvCopy {
-    StandardEnvironment copy;
+  ConfigurableEnvironment copy;
 
-    @SuppressWarnings({"rawtypes", "ConstantConditions"})
-    public EnvCopy(final ConfigurableEnvironment environment) {
-        copy = new StandardEnvironment();
-        Optional.ofNullable(environment.getPropertySources()).ifPresent(sources -> sources.forEach(ps -> {
-            final PropertySource<?> original = ps instanceof EncryptablePropertySource
-                    ? ((EncryptablePropertySource) ps).getDelegate()
-                    : ps;
-            copy.getPropertySources().addLast(original);
-        }));
-    }
+  ConfigurableEnvironment old;
 
-    public ConfigurableEnvironment get() {
-        return copy;
+  @SuppressWarnings({ "rawtypes", "ConstantConditions" })
+  public EnvCopy(final ConfigurableEnvironment environment) {
+    copy = new AbstractEnvironment() {
+    };
+    // copy = new StandardEnvironment();
+    old = environment;
+    clonePropertySources(environment);
+  }
+
+  private void clonePropertySources(final ConfigurableEnvironment environment) {
+    MutablePropertySources propertySources = environment.getPropertySources();
+    if (propertySources == null) {
+      if (environment instanceof StandardEncryptableEnvironment) {
+        propertySources = ((StandardEncryptableEnvironment) environment).getOriginalPropertySources();
+      } else if (environment instanceof StandardEncryptableServletEnvironment) {
+        propertySources = ((StandardEncryptableServletEnvironment) environment).getOriginalPropertySources();
+      }
+
     }
+    MutablePropertySources propertySourcesNew = copy.getPropertySources();
+    for (PropertySource<?> source : propertySourcesNew) {
+      propertySourcesNew.remove(source.getName());
+    }
+    Optional.ofNullable(propertySources).ifPresent(sources -> sources.forEach(ps -> {
+      final PropertySource<?> original = ps instanceof EncryptablePropertySource
+          ? ((EncryptablePropertySource) ps).getDelegate()
+          : ps;
+      propertySourcesNew.addLast(original);
+    }));
+  }
+
+  public ConfigurableEnvironment get() {
+    return copy;
+  }
+
+  public MutablePropertySources getPropertySources(String propertySourceName) {
+    final MutablePropertySources propertySources = copy.getPropertySources();
+    if (propertySourceName != null && !propertySources.contains(propertySourceName)) {
+        clonePropertySources(old);
+        return copy.getPropertySources();
+    }
+    return propertySources;
+  }
 }

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/environment/StandardEncryptableEnvironment.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/environment/StandardEncryptableEnvironment.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class StandardEncryptableEnvironment extends StandardEnvironment implements ConfigurableEnvironment {
 
     private MutablePropertySources encryptablePropertySources;
-    private MutablePropertySources originalPropertySources;
+    protected MutablePropertySources originalPropertySources;
 
     public StandardEncryptableEnvironment() {
         this(null, null, null, null, null, null);

--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/environment/StandardEncryptableServletEnvironment.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/environment/StandardEncryptableServletEnvironment.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class StandardEncryptableServletEnvironment extends StandardServletEnvironment implements ConfigurableEnvironment {
 
     private MutablePropertySources encryptablePropertySources;
-    private MutablePropertySources originalPropertySources;
+    protected MutablePropertySources originalPropertySources;
 
     public StandardEncryptableServletEnvironment() {
         this(null, null, null, null, null, null);
@@ -59,5 +59,9 @@ public class StandardEncryptableServletEnvironment extends StandardServletEnviro
     @Override
     public MutablePropertySources getPropertySources() {
         return this.encryptablePropertySources;
+    }
+
+    public MutablePropertySources getOriginalPropertySources() {
+        return originalPropertySources;
     }
 }


### PR DESCRIPTION
```
@SpringBootApplication
public class DemoSpringApplication {

    public static void main(String[] args) {
      SpringApplication app = new SpringApplication(DemoSpringApplication.class);
      StandardEncryptableEnvironment environment = new StandardEncryptableEnvironment();
      app.setEnvironment(environment);
      app.run(args);
    }

}
```
===>

```
java.lang.IllegalArgumentException: PropertySource named 'systemEnvironment' does not exist
	at org.springframework.core.env.MutablePropertySources.assertPresentAndGetIndex(MutablePropertySources.java:228) ~[spring-core-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at org.springframework.core.env.MutablePropertySources.replace(MutablePropertySources.java:176) ~[spring-core-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at com.ulisesbocchio.jasyptspringboot.aop.EncryptableMutablePropertySourcesInterceptor.invoke(EncryptableMutablePropertySourcesInterceptor.java:48) ~[classes/:na]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750) ~[spring-aop-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:692) ~[spring-aop-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at org.springframework.core.env.MutablePropertySources$$EnhancerBySpringCGLIB$$d9e3a499.replace(<generated>) ~[spring-core-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at org.springframework.boot.env.SystemEnvironmentPropertySourceEnvironmentPostProcessor.replacePropertySource(SystemEnvironmentPropertySourceEnvironmentPostProcessor.java:64) ~[spring-boot-2.3.12.RELEASE.jar:2.3.12.RELEASE]
	at org.springframework.boot.env.SystemEnvironmentPropertySourceEnvironmentPostProcessor.postProcessEnvironment(SystemEnvironmentPropertySourceEnvironmentPostProcessor.java:54) ~[spring-boot-2.3.12.RELEASE.jar:2.3.12.RELEASE]
	at org.springframework.boot.context.config.ConfigFileApplicationListener.onApplicationEnvironmentPreparedEvent(ConfigFileApplicationListener.java:203) ~[spring-boot-2.3.12.RELEASE.jar:2.3.12.RELEASE]
	at org.springframework.boot.context.config.ConfigFileApplicationListener.onApplicationEvent(ConfigFileApplicationListener.java:191) ~[spring-boot-2.3.12.RELEASE.jar:2.3.12.RELEASE]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:172) ~[spring-context-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:165) ~[spring-context-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:139) ~[spring-context-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:127) ~[spring-context-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at org.springframework.boot.context.event.EventPublishingRunListener.environmentPrepared(EventPublishingRunListener.java:80) ~[spring-boot-2.3.12.RELEASE.jar:2.3.12.RELEASE]
	at org.springframework.boot.SpringApplicationRunListeners.environmentPrepared(SpringApplicationRunListeners.java:53) ~[spring-boot-2.3.12.RELEASE.jar:2.3.12.RELEASE]
	at org.springframework.boot.SpringApplication.prepareEnvironment(SpringApplication.java:342) ~[spring-boot-2.3.12.RELEASE.jar:2.3.12.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:307) ~[spring-boot-2.3.12.RELEASE.jar:2.3.12.RELEASE]
	at demo.DemoSpringApplication.main(DemoSpringApplication.java:20) [classes/:na]
```