### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,13 +8,28 @@ jobs:
     strategy:
       matrix:
         java: [ '8', '11', '12', '13', '15' ]
-    name: Java ${{ matrix.Java }} build
+    name: Java ${{ matrix.java }} Zulu build
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Java
+    - name: Set up Java ${{ matrix.java }} Zulu
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'zulu'
         java-version: ${{ matrix.java }}
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+  build_2:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '8', '11' ]
+    name: Java ${{ matrix.Java }} Temurin
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Java ${{ matrix.java }} Temurin
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml 


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK.

Signed-off-by: Carl Dea <carldea@gmail.com>