### PR TITLE
Make decrypt-value and encrypt-value mojos standalone runnable

### DIFF
--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/AbstractJasyptMojo.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/AbstractJasyptMojo.java
@@ -56,7 +56,7 @@ public abstract class AbstractJasyptMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException {
         Map<String, Object> defaultProperties = new HashMap<>();
-        defaultProperties.put("spring.config.location", "file:./src/main/resources/");
+        defaultProperties.put("spring.config.location", "optional:file:./src/main/resources/");
 
         ConfigurableApplicationContext context = new SpringApplicationBuilder()
                 .sources(Application.class)

--- a/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/DecryptValueMojo.java
+++ b/jasypt-maven-plugin/src/main/java/com/ulisesbocchio/jasyptmavenplugin/mojo/DecryptValueMojo.java
@@ -11,7 +11,7 @@ import org.apache.maven.plugins.annotations.Mojo;
  *
  * @author ubocchio
  */
-@Mojo(name = "decrypt-value", defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
+@Mojo(name = "decrypt-value", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresProject = false)
 @Slf4j
 public class DecryptValueMojo extends AbstractValueJasyptMojo {
 


### PR DESCRIPTION
https://github.com/ulisesbocchio/jasypt-spring-boot/pull/284 introduced standalone runnability for the `encrypt-value` mojo.
https://github.com/ulisesbocchio/jasypt-spring-boot/pull/220 introduced a regression that required the `./src/main/resources/` file structure to be present to be able to run a mojo, effectively breaking the standalone runnability (and also the runnability from e.g. the root of a multi module project).

This PR adds the same standalone runnability for the `decrypt-value` mojo as present for the `encrypt-value` mojo and fixes the regression by [making the config path optional](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.files.optional-prefix).

