### PR TITLE
fix: #326 修复 SpringCloud 下，远程配置文件修改（如Nacos），本地ConfigurationProperties 配置类没…

### DIFF
--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/caching/RefreshScopeRefreshedEventListener.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/caching/RefreshScopeRefreshedEventListener.java
@@ -10,17 +10,25 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.core.env.*;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.PropertySources;
 import org.springframework.util.ClassUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@Order(Ordered.HIGHEST_PRECEDENCE)
+@Order(Ordered.LOWEST_PRECEDENCE - 10)
 @Slf4j
-public class RefreshScopeRefreshedEventListener implements ApplicationListener<ApplicationEvent>, InitializingBean, Ordered {
+public class RefreshScopeRefreshedEventListener implements ApplicationListener<ApplicationEvent>, InitializingBean {
 
     public static final List<String> EVENT_CLASS_NAMES = Arrays.asList(
             "org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent",
@@ -97,10 +105,5 @@ public class RefreshScopeRefreshedEventListener implements ApplicationListener<A
                 .concat(EVENT_CLASS_NAMES.stream(), this.config.getRefreshedEventClasses().stream())
                 .map(this::getClassSafe).filter(Objects::nonNull)
                 .collect(Collectors.toCollection(() -> this.eventClasses));
-    }
-
-    @Override
-    public int getOrder() {
-        return Ordered.LOWEST_PRECEDENCE;
     }
 }


### PR DESCRIPTION
‘Spring Cloud’ 中绝大多数对 ‘Spring Environment’ 操作的组件，应当比 ‘ConfigurationPropertiesRebinder’ 优先级要高，否则就会出现 ‘ConfigurationProperties’ 配置类更新不及时的问题。所以建议这里的 ‘RefreshScopeRefreshedEventListener’ 优先级不要设置成最低，只要比 ‘ConfigurationPropertiesRebinder’  高即可；
-- from the technical team of YXT(yxt.com)

The vast majority of components in 'spring cloud' that operate on 'spring environment' should have higher priority than 'configurationpropertiesrebinder'. Otherwise, the 'configurationproperties' configuration class will not be updated in time. Therefore, it is recommended that the priority of 'refreshscoperefreshedeventlistener' should not be set to the lowest, as long as it is higher than 'configurationpropertiesrebinder';
