### PR TITLE
Fixes ulisesbocchio/jasypt-spring-boot#330

### DIFF
--- a/jasypt-spring-boot-starter/pom.xml
+++ b/jasypt-spring-boot-starter/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>uk.org.webcompere</groupId>
             <artifactId>system-stubs-jupiter</artifactId>
-            <version>1.2.0</version>
+            <version>2.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Project can be built using JDK 16+ (it will still compiled to JDK 8 compatible code).