### PR TITLE
Solve: the dynamically updated property value cannot be obtained, and the concurrency problem

### DIFF
--- a/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/caching/CachingDelegateEncryptablePropertySource.java
+++ b/jasypt-spring-boot/src/main/java/com/ulisesbocchio/jasyptspringboot/caching/CachingDelegateEncryptablePropertySource.java
@@ -3,9 +3,12 @@ package com.ulisesbocchio.jasyptspringboot.caching;
 import com.ulisesbocchio.jasyptspringboot.EncryptablePropertyFilter;
 import com.ulisesbocchio.jasyptspringboot.EncryptablePropertyResolver;
 import com.ulisesbocchio.jasyptspringboot.EncryptablePropertySource;
-import java.util.HashMap;
-import java.util.Map;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.PropertySource;
 import org.springframework.util.Assert;
@@ -15,7 +18,7 @@ public class CachingDelegateEncryptablePropertySource<T> extends PropertySource<
     private final PropertySource<T> delegate;
     private final EncryptablePropertyResolver resolver;
     private final EncryptablePropertyFilter filter;
-    private final Map<String, Object> cache;
+    private final Map<String, CachedValue> cache;
 
     public CachingDelegateEncryptablePropertySource(PropertySource<T> delegate, EncryptablePropertyResolver resolver, EncryptablePropertyFilter filter) {
         super(delegate.getName(), delegate.getSource());
@@ -25,7 +28,7 @@ public class CachingDelegateEncryptablePropertySource<T> extends PropertySource<
         this.delegate = delegate;
         this.resolver = resolver;
         this.filter = filter;
-        this.cache = new HashMap<>();
+        this.cache = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -35,24 +38,48 @@ public class CachingDelegateEncryptablePropertySource<T> extends PropertySource<
 
     @Override
     public Object getProperty(String name) {
-        // Can be called recursively, so, we cannot use computeIfAbsent.
-        if (cache.containsKey(name)) {
-            return cache.get(name);
+        //The purpose of this cache is to reduce the cost of decryption,
+        // so it's not a bad idea to read the original property every time, it's generally fast.
+        Object originValue = delegate.getProperty(name);
+        if (!(originValue instanceof String)) {
+            //Because we read the original property every time, if it isn't a String,
+            // there's no point in caching it.
+            return originValue;
         }
-        synchronized (name.intern()) {
-            if (!cache.containsKey(name)) {
-                Object resolved = getProperty(resolver, filter, delegate, name);
-                if (resolved != null) {
-                    cache.put(name, resolved);
-                }
+
+        CachedValue cachedValue = cache.get(name);
+        if (cachedValue != null && Objects.equals(originValue, cachedValue.originValue)) {
+            // If the original property has not changed, it is safe to return the cached result.
+            return cachedValue.resolvedValue;
+        }
+
+        //originValue must be String here
+        if (filter.shouldInclude(delegate, name)) {
+            String originStringValue = (String) originValue;
+            String resolved = resolver.resolvePropertyValue(originStringValue);
+            CachedValue newCachedValue = new CachedValue(originStringValue, resolved);
+            //If the mapping relationship in the cache changes during
+            // the calculation process, then ignore it directly.
+            if (cachedValue == null) {
+                cache.putIfAbsent(name, newCachedValue);
+            } else {
+                cache.replace(name, cachedValue, newCachedValue);
             }
-            return cache.get(name);
+            //return the result calculated this time
+            return resolved;
         }
+        return originValue;
     }
 
     @Override
     public void refresh() {
         log.info("Property Source {} refreshed", delegate.getName());
         cache.clear();
+    }
+
+    @AllArgsConstructor
+    private static class CachedValue {
+        private final String originValue;
+        private final String resolvedValue;
     }
 }


### PR DESCRIPTION
The original code:
```
public class CachingDelegateEncryptablePropertySource<T> ...
    ...
    private final Map<String, Object> cache;
    ...

    @Override
    public Object getProperty(String name) {
        // Can be called recursively, so, we cannot use computeIfAbsent.
        if (cache.containsKey(name)) {
            return cache.get(name);
        }
        synchronized (name.intern()) {
            if (!cache.containsKey(name)) {
                Object resolved = getProperty(resolver, filter, delegate, name);
                if (resolved != null) {
                    cache.put(name, resolved);
                }
            }
            return cache.get(name);
        }
    }

    @Override
    public void refresh() {
        log.info("Property Source {} refreshed", delegate.getName());
        cache.clear();
    }
}
```

If we want to use `HashMap` under multi-thread, then whether it is a read method or a write method, it needs to be protected with a synchronized block or lock. In the `refresh` method, we directly call the `clear` method of `HashMap`, which is not thread-safe. In addition, in the `getProperty` method, using `synchronized (name.intern())` to achieve thread safety is actually risky. The same lock must be used to ensure that each thread can access the code protected by the lock mutually exclusive. If there are multiple locks , there is still a risk of reentrancy.

In this scenario, using `ConcurrentHashMap` directly is still a good choice.

In addition, considering that the main purpose of this cache is to reduce the cost of decryption, I changed the way of thinking to solve the problem that the new value cannot be obtained when the property is updated (in the original solution, the cache was not cleared in time), the new solution no longer rely on cache clearing, and even the related refresh code can be removed.

Design idea of ​​the new solution: when caching data, store the original property value and decryption result together. When reading the property, first obtain the original property value through the `delegate.getProperty`. If there is a corresponding cache, compare the two original values. If they are the same, return the cached decryption result, otherwise recalculate the decryption result, which ensures that when the property value changes, it can be automatically recalculated instead of using the cached old data.

After my test, this solution can solve the problem that the hot update of `com.ctrip.framework.apollo : apollo-client` configuration does not take effect.


如果我们想在多线程下使用`HashMap`，那么不管是读方法还是写方法，都需要用同步块或锁保护起来。在`refresh`方法中，我们直接调用了`HashMap`的`clear`方法，这是不安全的。另外在`getProperty`方法中，使用`synchronized (name.intern())`来达到线程安全，实际上也存在风险，必须用同一把锁才能保证各线程互斥地访问被锁保护的代码，如果是多把锁，则仍存在重入的风险。

此场景下，直接使用`ConcurrentHashMap`仍旧是一个不错的选择。

另外，考虑到本缓存的主要目的是减少解密的成本，所以我换了一种思路，来解决属性更新时无法取到新值的问题（在原方案中，缓存没有被及时的清除），新方案不再依赖于主动清除缓存，甚至可以移除掉相关的刷新代码。

新方案设计思路：缓存数据的时候，把原始属性值和解密结果一同存起来，在读取属性的时候，先通过`delegate.getProperty`获取原始属性值，如果存在存对应的缓存，则先比较两个原始值是否相同，如果相同则返回缓存的解密结果，否则重新计算解密结果，这样便保证了当属性值发生变更时，能自动重新计算，而不是使用缓存的旧数据。

经过我的测试，此方案，可以解决`com.ctrip.framework.apollo : apollo-client`配置热更新不生效的问题。