### PR TITLE
Spring Boot 3 changes w/ backwards compatibility

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -51,4 +51,4 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - name: Build with Maven
-        run: mvn -B package --file pom.xml -Dspring.boot.version=3.0.0-SNAPSHOT -Dspring.cloud.version=2022.0.0-SNAPSHOT
+        run: mvn -B package --file pom.xml -Dspring.boot.version=3.0.0 -Dspring.cloud.version=2022.0.0-M5

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -51,4 +51,4 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - name: Build with Maven
-        run: mvn -B package --file pom.xml -Dspring.boot.version=3.0.0 -Dspring.cloud.version=2022.0.0-M5
+        run: mvn -B package --file pom.xml -Dspring.boot.version=3.0.0 -Dspring.cloud.version=2022.0.0-RC2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,12 +2,16 @@ name: Java CI
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '12', '13', '15' ]
+        java: [ '8', '11', '12', '13', '15', '16', '17', '19' ]
     name: Java ${{ matrix.java }} Zulu build
     steps:
     - uses: actions/checkout@v2
@@ -33,3 +37,18 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: Build with Maven
       run: mvn -B package --file pom.xml 
+  build_3:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '17', '18', '19' ]
+    name: Java ${{ matrix.java }} Zulu build w/ Spring Boot 3
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Java ${{ matrix.java }} Zulu
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml -Dspring.boot.version=3.0.0-SNAPSHOT -Dspring.cloud.version=2022.0.0-SNAPSHOT

--- a/jasypt-maven-plugin/pom.xml
+++ b/jasypt-maven-plugin/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <maven.api.version>2.2.1</maven.api.version>
         <maven-plugin-annotations.version>3.3</maven-plugin-annotations.version>
-        <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
+        <maven-plugin-plugin.version>3.7.0</maven-plugin-plugin.version>
     </properties>
 
     <dependencies>

--- a/jasypt-spring-boot-starter/pom.xml
+++ b/jasypt-spring-boot-starter/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>uk.org.webcompere</groupId>
             <artifactId>system-stubs-jupiter</artifactId>
-            <version>1.2.0</version>
+            <version>2.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jasypt-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/jasypt-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.ulisesbocchio.jasyptspringbootstarter.JasyptSpringBootAutoConfiguration

--- a/jasypt-spring-boot-starter/src/test/java/com/ulisesbocchio/jasyptspringbootstarter/resolver/DefaultPropertyResolverTest.java
+++ b/jasypt-spring-boot-starter/src/test/java/com/ulisesbocchio/jasyptspringbootstarter/resolver/DefaultPropertyResolverTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -32,29 +31,30 @@ class TestApp {
 }
 @SpringBootTest(
         properties = {
-                "spring.config.use-legacy-processing=true"
+                "spring.config.use-legacy-processing=true",
+                "server.port=9625"
         },
         classes = TestApp.class,
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class DefaultPropertyResolverTest {
+        webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT
+        )
+class DefaultPropertyResolverTest {
 
     @Value("${spring.cloud.config.server.svn.password}")
     public String secret;
 
-    @LocalServerPort
-    public int port;
+    public int port = 9625;
 
     @Autowired
     private Environment env;
 
     @Test
-    public void encryptedPropertyIsDecryptedInEnvironment() {
+    void encryptedPropertyIsDecryptedInEnvironment() {
         assertThat(env.getProperty("spring.cloud.config.server.svn.password")).isEqualTo("mypassword");
         assertThat(secret).isEqualTo("mypassword");
     }
 
     @Test
-    public void propertiesAreAccessibleFromEnvActuator() {
+    void propertiesAreAccessibleFromEnvActuator() {
         ResponseEntity<?> response = new RestTemplateBuilder()
                 .errorHandler(ErrorHandler.DEFAULT)
                 .build().exchange(RequestEntity

--- a/jasypt-spring-boot-starter/src/test/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/jasypt-spring-boot-starter/src/test/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.ulisesbocchio.jasyptspringbootstarter.JasyptSpringBootAutoConfiguration

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <spring.boot.version>2.7.5</spring.boot.version>
+        <spring.boot.version>2.7.6</spring.boot.version>
         <spring.cloud.version>2021.0.5</spring.cloud.version>
         <jasypt.version>1.9.3</jasypt.version>
         <maven.compiler.version>3.10.1</maven.compiler.version>
@@ -210,40 +210,4 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    <repositories>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>spring-snapshots</id>
-            <name>Spring Snapshots</name>
-            <url>https://repo.spring.io/snapshot</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-        <pluginRepository>
-            <id>spring-snapshots</id>
-            <name>Spring Snapshots</name>
-            <url>https://repo.spring.io/snapshot</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </pluginRepository>
-    </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.ulisesbocchio</groupId>
@@ -13,12 +14,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <spring.boot.version>2.5.4</spring.boot.version>
-        <spring.cloud.version>2020.0.3</spring.cloud.version>
+        <spring.boot.version>2.7.5</spring.boot.version>
+        <spring.cloud.version>2021.0.5</spring.cloud.version>
         <jasypt.version>1.9.3</jasypt.version>
-        <maven.compiler.version>3.8.1</maven.compiler.version>
+        <maven.compiler.version>3.10.1</maven.compiler.version>
         <system.rules.version>1.19.0</system.rules.version>
-        <start-class>Application</start-class>
     </properties>
 
     <modules>
@@ -44,8 +44,8 @@
         <url>https://github.com/ulisesbocchio/jasypt-spring-boot</url>
         <connection>scm:git:git://github.com/ulisesbocchio/jasypt-spring-boot.git</connection>
         <developerConnection>scm:git:git@github.com:ulisesbocchio/jasypt-spring-boot.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <developers>
         <developer>
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.0.0-M4</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <useReleaseProfile>false</useReleaseProfile>
@@ -103,24 +103,9 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>${spring.boot.version}</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>repackage</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <mainClass>${start-class}</mainClass>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>3.0.0-M7</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -169,7 +154,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.4</version>
+                        <version>3.4.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -204,11 +189,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jasypt</groupId>
                 <artifactId>jasypt</artifactId>
                 <version>${jasypt.version}</version>
@@ -230,24 +210,40 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-<!--    <repositories>-->
-<!--        <repository>-->
-<!--            <id>spring-milestones</id>-->
-<!--            <name>Spring Milestones</name>-->
-<!--            <url>https://repo.spring.io/libs-milestone</url>-->
-<!--            <snapshots>-->
-<!--                <enabled>false</enabled>-->
-<!--            </snapshots>-->
-<!--        </repository>-->
-<!--    </repositories>-->
-<!--    <pluginRepositories>-->
-<!--        <pluginRepository>-->
-<!--            <id>spring-milestones</id>-->
-<!--            <name>Spring Milestones</name>-->
-<!--            <url>https://repo.spring.io/libs-milestone</url>-->
-<!--            <snapshots>-->
-<!--                <enabled>false</enabled>-->
-<!--            </snapshots>-->
-<!--        </pluginRepository>-->
-<!--    </pluginRepositories>-->
+    <repositories>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -210,4 +210,40 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <repositories>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
 </project>


### PR DESCRIPTION

- New src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports file for SB3 AutoConfiguration beans
- New src/test/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports file for SB3 AutoConfiguration beans
- Use pre-defined port for DefaultPropertyResolverTest due to @LocalServerPort moving to test packages in SB3
- Update Spring Boot 2 and Spring Cloud versions to latest releases
- Add additional workflow builds that set SB3 and Spring Cloud 2022.x snapshot versions for Java 17+
- Update all plugin versions to latest
- Update system-stubs-jupiter to latest release for Java 16+ test compatibility
- Add Spring Boot snapshot and milestone repositories (should be fine to leave, but we can pull once SB3 releases Thursday)
- Add concurrency field to build workflow to cancel in progress builds for same branch
- Remove un-needed spring-boot-maven-plugin

![image](https://user-images.githubusercontent.com/3778394/202938848-ce0c103a-dd99-4c89-8b99-9165c59d6979.png)


Thanks!
